### PR TITLE
Allow writing hspec tests against Hoogle library

### DIFF
--- a/datadir/testdata.txt
+++ b/datadir/testdata.txt
@@ -45,6 +45,9 @@ class Eq2 a b => Ord2 a b | a -> b
 
 module Foo.Bar
 foo_bar :: Unit
+fst :: (Unit,Unit) -> Unit
+fst2 :: (Unit,Unit) -> Unit
 
 module Bar.Foo
 bar_foo :: Unit
+fst :: (Bar,Bar) -> Bar

--- a/hoogle.cabal
+++ b/hoogle.cabal
@@ -1,4 +1,4 @@
-cabal-version:      >= 1.6
+cabal-version:      >= 1.10
 build-type:         Simple
 name:               hoogle
 version:            4.2.15
@@ -32,15 +32,22 @@ source-repository head
     location: http://code.haskell.org/hoogle/
 
 library
-    hs-source-dirs:     src
+    hs-source-dirs: src
+    default-language: Haskell98
+
     build-depends:
         base > 4 && < 5,
         array, bytestring, containers, directory, filepath, process, random,
         safe,
         binary,
+        conduit >= 0.2,
         parsec >= 2.1,
         transformers >= 0.2,
         uniplate >= 1.6,
+        blaze-builder >= 0.2,
+        case-insensitive >= 0.2,
+        http-types >= 0.7,
+        wai >= 1.1,
         haskell-src-exts >= 1.12 && < 1.14
 
     if !os(mingw32)
@@ -103,18 +110,26 @@ library
 executable hoogle
     main-is:            Main.hs
     hs-source-dirs:     src
+    default-language: Haskell98
 
     build-depends:
-        time, old-time, old-locale,
+        base > 4 && < 5,
+        hoogle, bytestring, filepath, unix, directory, process, random,
+        array, containers, time, old-time, old-locale,
+        safe,
         cmdargs >= 0.7,
         tagsoup >= 0.11,
         blaze-builder >= 0.2,
         http-types >= 0.7,
         case-insensitive >= 0.2,
+        transformers >= 0.2,
+        uniplate >= 1.6,
         conduit >= 0.2,
+        parsec >= 2.1,
         wai >= 1.1,
         warp >= 1.1,
-        Cabal >= 1.8
+        Cabal >= 1.8,
+        haskell-src-exts >= 1.12 && < 1.14
 
     other-modules:
         CmdLine.All
@@ -144,3 +159,19 @@ executable hoogle
         Web.Response
         Web.Server
         Web.Template
+
+test-suite hoogle-test
+    main-is: HoogleSpec.hs
+    hs-source-dirs: test
+    default-language: Haskell98
+
+    type: exitcode-stdio-1.0
+    build-depends:
+        base >=3,
+        hoogle,
+        conduit >= 0.2,
+        system-fileio >= 0.3.11,
+        transformers >= 0.2,
+        HUnit >= 1.2.5,
+        hspec >= 1.4.4,
+        hspec-expectations >= 0.3

--- a/src/Console/Log.hs
+++ b/src/Console/Log.hs
@@ -67,7 +67,7 @@ data Entry = Entry
     ,unique :: Maybe String -- maybe a uniquely identifying string
     ,instant :: Maybe Int -- number of times you hit with instant for this query
     ,suggest :: Maybe Int -- number of times you hit with suggest for this query
-    } deriving Show
+    } deriving (Eq, Show)
 
 entry = Entry LBS.empty [] Nothing Nothing Nothing Nothing Nothing
 

--- a/src/Hoogle.hs
+++ b/src/Hoogle.hs
@@ -106,6 +106,7 @@ data Result = Result
     ,self :: TagStr -- ^ Rendered view for the entry, including name/keywords/type as appropriate, colors matching 'renderQuery'
     ,docs :: TagStr -- ^ Documentation for the entry
     }
+    deriving (Eq, Show)
 
 toResult :: H.Result -> (Score,Result)
 toResult r@(H.Result ent view score) = (score, Result parents self docs)

--- a/src/Hoogle/Type/Item.hs
+++ b/src/Hoogle/Type/Item.hs
@@ -58,7 +58,7 @@ data Entry = Entry
     ,entryKey :: String -- used only for rebuilding combined databases
     ,entryType :: Maybe TypeSig -- used only for rebuilding combined databases
     }
-    deriving Typeable
+    deriving (Eq, Typeable)
 
 
 -- | Figure out what makes this entry different from others
@@ -77,7 +77,7 @@ entryURL e = head $ map fst (entryLocations e) ++ [""]
 
 data EntryView = FocusOn String -- characters in the range should be focused
                | ArgPosNum Int Int -- argument a b, a is remapped to b
-                 deriving Show
+                 deriving (Eq, Show)
 
 
 renderEntryText :: [EntryView] -> TagStr -> TagStr

--- a/src/Hoogle/Type/Result.hs
+++ b/src/Hoogle/Type/Result.hs
@@ -11,7 +11,7 @@ data Result = Result
     ,resultView :: [EntryView]
     ,resultScore :: Score
     }
-    deriving Show
+    deriving (Eq, Show)
 
 
 -- return the entry rendered with respect to the EntryView

--- a/test/HoogleSpec.hs
+++ b/test/HoogleSpec.hs
@@ -1,0 +1,63 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Main where
+
+import           Control.Monad
+import           Control.Monad.IO.Class
+import           Data.Monoid
+import           Filesystem (isDirectory, isFile)
+import qualified Hoogle as H
+import           System.Environment
+import           System.Exit
+import           System.IO
+import           Test.HUnit
+import           Test.Hspec (Spec, describe, it, hspec)
+import           Test.Hspec.Expectations
+import           Test.Hspec.HUnit ()
+import           Test.Hspec.Runner
+
+main :: IO ()
+main = do
+    env <- getEnvironment
+    hoogledb <- liftIO $
+        readFileUtf8 "datadir/testdata.txt"
+            >>= return . snd . H.createDatabase H.Haskell []
+    hspec $ hoogleSpec hoogledb
+
+readFileUtf8 x = do
+    h <- openFile x ReadMode
+    hSetEncoding h utf8
+    hGetContents h
+
+hoogleSpec :: H.Database -> Spec
+hoogleSpec db = do
+    describe "Basic functionality" $ do
+        it "finds 'snd'" $ do
+            let q = H.parseQuery undefined "snd"
+            map (H.self . snd) (H.search db (either mempty id q))
+                @?= [H.Tags [ H.TagBold (H.Tags [H.TagEmph (H.Str "snd")])
+                            , H.Str " :: "
+                            , H.Str "(a,b)"
+                            , H.Str " -> "
+                            , H.Str "b" ]]
+
+        it "finds four instances of 'fst'" $ do
+            let q = H.parseQuery undefined "fst"
+            length (H.search db (either mempty id q)) @?= 4
+
+        it "finds two 'Foo.Bar.fst*' inexactly" $ do
+            let q = H.parseQuery undefined "fst +Foo.Bar"
+            length (H.search db (either mempty id q)) @?= 2
+
+        it "finds 'Foo.Bar.fst' exactly" $ do
+            let q = H.parseQuery undefined "fst +Foo.Bar"
+            map (H.self . snd)
+                (H.search db (H.queryExact (Just H.UnclassifiedItem)
+                                           (either mempty id q)))
+                @?= [H.Tags [ H.TagBold (H.Tags [H.TagEmph (H.Str "fst")])
+                            , H.Str " :: "
+                            , H.Str "(Unit,Unit)"
+                            , H.Str " -> "
+                            , H.Str "Unit" ]]
+
+-- Smoke.hs ends here


### PR DESCRIPTION
This patch begins the creation of hspec-based tests against Hoogle as a library, since that is the mode of usage we depend on most, and this will ensure that features we add in future do not break current functionality we depend on.

The only questionable aspect of this patch is the nature of the changes I had to make to hoogle.cabal, which now moves to a dependency on at least cabal 1.10.
