### PR TITLE
Make inexact queries much more heuristic

### DIFF
--- a/src/Hoogle/Search/All.hs
+++ b/src/Hoogle/Search/All.hs
@@ -1,7 +1,9 @@
 
 module Hoogle.Search.All(search) where
 
+import Data.List (sortBy)
 import Data.Maybe
+import Data.Ord (comparing)
 import Hoogle.DataBase.All
 import Hoogle.Query.All
 import Hoogle.Search.Results
@@ -15,7 +17,8 @@ search databases query = getResults query databases
 
 
 getResults :: Query -> [DataBase] -> [Result]
-getResults query = mergeDataBaseResults . map (mergeQueryResults query . f)
+getResults query = sortBy (comparing resultScore) .
+                   mergeDataBaseResults . map (mergeQueryResults query . f)
     where
         f d = [ typeSearch d q
               | Just q <- [typeSig query], isNothing (exactSearch query) ] ++

--- a/src/Hoogle/Search/Results.hs
+++ b/src/Hoogle/Search/Results.hs
@@ -25,7 +25,6 @@ instance Ord k => Ord (Key k v) where
 
 toKey f v = Key (f v) v
 fromKey (Key k v) = v
-sortWith f = map fromKey . sort . map (toKey f)
 
 
 ---------------------------------------------------------------------
@@ -49,13 +48,12 @@ mergeQueryResults q = filterResults q . joinResults
 joinResults :: [[Result]] -> [Result]
 joinResults [] = []
 joinResults [x] = x
-joinResults xs = sortWith resultScore $ Map.elems $
-                 fold1 (Map.intersectionWith join) $
+joinResults xs = Map.elems $ fold1 (Map.intersectionWith join) $
                  map asSet xs
     where
         asSet = Map.fromList . map (entryUnique . resultEntry &&& id)
 
-        join r1 r2 = r1{resultScore = mappend (resultScore r1) (resultScore r2)
+        join r1 r2 = r1{resultScore = resultScore r1 <> resultScore r2
                        ,resultView = resultView r1 ++ resultView r2
                        ,resultEntry = resultEntry r1 `entryJoin` resultEntry r2}
 


### PR DESCRIPTION
For example, exact matches with respect to case are always at the top.
Next come prefix matches with respect to case, then case insensitive
exact matches, then case insensitive prefix matches, then substring
matches.  Sorting of results weights exactitude higher than the number
of times something was seen.  Sorting is done after databases are
merged.

With these changes, the queries for "map" and "Map", or "bimap" and
"Bimap", return what you'd expect to see first.  Otherwise, it's rather
hard to search for Map, since there are were many case insensitive
identifiers that have map as a substring.  Basically you couldn't find
it without specify the package or the module.
