### PR TITLE
A query term like *map inverts the sense of a query

### DIFF
--- a/src/Hoogle/Query/Type.hs
+++ b/src/Hoogle/Query/Type.hs
@@ -12,13 +12,14 @@ data Query = Query
     ,typeSig :: Maybe TypeSig
     ,scope :: [Scope]
     ,exactSearch :: Maybe ItemKind
+    ,invertResults :: Bool
     }
     deriving (Data,Typeable,Show,Eq)
 
 instance Monoid Query where
-    mempty = Query [] Nothing [] Nothing
-    mappend (Query x1 x2 x3 x4) (Query y1 y2 y3 y4) =
-        Query (x1++y1) (x2 `mplus` y2) (x3++y3) (merge x4 y4)
+    mempty = Query [] Nothing [] Nothing False
+    mappend (Query x1 x2 x3 x4 x5) (Query y1 y2 y3 y4 y5) =
+        Query (x1++y1) (x2 `mplus` y2) (x3++y3) (merge x4 y4) (x5 || y5)
       where merge Nothing Nothing = Nothing
             merge (Just x) Nothing = Just x
             merge Nothing (Just y) = Just y

--- a/src/Hoogle/Search/All.hs
+++ b/src/Hoogle/Search/All.hs
@@ -17,7 +17,8 @@ search databases query = getResults query databases
 
 
 getResults :: Query -> [DataBase] -> [Result]
-getResults query = sortBy (comparing resultScore) .
+getResults query = sortBy ((if invertResults query then flip else id)
+                           $ comparing resultScore) .
                    mergeDataBaseResults . map (mergeQueryResults query . f)
     where
         f d = [ typeSearch d q


### PR DESCRIPTION
In particular, this causes all substring matches to come to the top, and
exact matches to go the bottom.  Useful if you can only remember one
word that the function contained, but nothing else.
