### PR TITLE
Use `aeson` for generating `mode=json` response

### DIFF
--- a/hoogle.cabal
+++ b/hoogle.cabal
@@ -119,6 +119,7 @@ executable hoogle
         hoogle, bytestring, filepath, unix, directory, process, random,
         array, containers, time, old-time, old-locale,
         safe,
+        aeson >= 0.6.1,
         cmdargs >= 0.7,
         deepseq >= 1.1,
         tagsoup >= 0.11,

--- a/src/Web/Response.hs
+++ b/src/Web/Response.hs
@@ -10,6 +10,8 @@ import General.Web
 import Web.Page
 import Data.Generics.Uniplate
 
+import qualified Data.Aeson as J
+import qualified Data.ByteString.Lazy.Char8 as LBS
 import Data.Time.Clock
 import Data.Time.Format
 import System.Locale
@@ -47,7 +49,7 @@ response ResponseArgs{..} q = do
         Just "embed" -> return $ response "text/html" [hdr] $ runEmbed dbs q
             where hdr = (fromString "Access-Control-Allow-Origin", fromString "*")
         Just "ajax" -> return $ response "text/html" [] $ runQuery templates True dbs q
-        Just "json" -> return $ response "application/json" [] $ "{\"version\":" ++ show version ++ "," ++ runJson dbs q ++ "}"
+        Just "json" -> return $ responseOK [(hContentType, fromString "application/json")] $ runJson dbs q
         Just "web" -> return $ response "text/html" [] $
             header templates updatedCss updatedJs (queryText q) ['-' | queryText q /= ""] ++
             runQuery templates False dbs q ++ footer templates version
@@ -88,19 +90,28 @@ runEmbed dbs cq@Search{queryParsed = Right q}
         f x = x
 
 
-runJson :: Database -> CmdLine -> String
-runJson dbs Search{queryParsed = Left err} = "\"parseError\": " ++ show err
-runJson dbs cq@Search{queryParsed = Right q}
-    | q == mempty = "\"results\": []"
-    | otherwise = "\"results\": [" ++ intercalate "," now ++ "]"
-        where
-            start2 = maybe 0 (subtract 1 . max 0) $ start cq
-            count2 = maybe 20 (max 1) $ count cq
-            now = map (f . snd) $ take count2 $ drop start2 $ search dbs q
+runJson :: Database -> CmdLine -> LBS.ByteString
+runJson dbs Search{queryParsed = Left err} =
+    J.encode $ J.object [ fromString "version"    J..= version
+                        , fromString "parseError" J..= show err
+                        ]
+runJson dbs cq@Search{queryParsed = Right q} =
+    J.encode $ J.object [ fromString "version"    J..= version
+                        , fromString "results"    J..= results
+                        ]
+    where
+        results | q == mempty = []
+                | otherwise   = now
 
-            f Result{..} = "{\"location\":" ++ show (head $ map fst locations ++ [""]) ++
-                           ",\"self\":" ++ show (showTagText self) ++
-                           ",\"docs\":" ++ show (showTagText docs) ++ "}"
+        start2 = maybe 0 (subtract 1 . max 0) $ start cq
+        count2 = maybe 20 (max 1) $ count cq
+        now = map (f . snd) $ take count2 $ drop start2 $ search dbs q
+
+        f Result{..} = J.object
+                       [ fromString "location" J..= (head $ map fst locations ++ [""])
+                       , fromString "self" J..= showTagText self
+                       , fromString "docs" J..= showTagText docs
+                       ]
 
 
 runQuery :: Templates -> Bool -> Database -> CmdLine -> String


### PR DESCRIPTION
This fixes the previous fragile way of synthesizing JSON by manual
string concatenations which sometimes results in invalid JSON
responses. Moreover, the lazy bytestring emitted by `aeson`'s encoder
is directly fed into WAI's response structure w/o the need to go
through `String`.
