### PR TITLE
Fix failing tests #25

### DIFF
--- a/hoogle.cabal
+++ b/hoogle.cabal
@@ -17,6 +17,7 @@ homepage:           http://www.haskell.org/hoogle/
 bug-reports:        https://github.com/ndmitchell/hoogle/issues
 stability:          Beta
 extra-source-files: README.txt
+                    datadir/*.txt
 
 data-dir: datadir
 data-files:


### PR DESCRIPTION
These are just two minor cabal file tweaks: one to refer to the source location on Github, and the other to add some missing test files for the sdist tarball.
