### PR TITLE
Ask if a tarball exists before trying to extract its contents

### DIFF
--- a/src/Recipe/Download.hs
+++ b/src/Recipe/Download.hs
@@ -47,8 +47,8 @@ download opt = do
                 , (inputs <.> "txt", inputs <.> "tar.gz", "http://old.hackage.haskell.org/packages/archive/00-hoogle.tar.gz")
                 ]
     withDownloader opt downloader items
-    extractTarball cabals
-    extractTarball inputs
+    doesFileExist (cabals <.> "tar.gz") >>= \b -> when b $ extractTarball cabals
+    doesFileExist (inputs <.> "tar.gz") >>= \b -> when b $ extractTarball inputs
 
 
 check :: String -> IO (Maybe FilePath)


### PR DESCRIPTION
When the contents of a tarball are already present in the filesystem,
hoogle will not download it again. In this case, the tarball must not be
extracted because it does not exists.
