### PR TITLE
Correct URLs to favicon in OpenSearch

### DIFF
--- a/datadir/resources/search.xml
+++ b/datadir/resources/search.xml
@@ -11,8 +11,8 @@
     <Url type="text/html" template="http://haskell.org/hoogle/?hoogle={searchTerms}"/>
     <Url type="application/x-suggestions+json" template="http://haskell.org/hoogle/?hoogle={searchTerms}&amp;mode=suggest"/>
 
-    <Image height="16" width="16" type="image/png">http://haskell.org/hoogle/datadir/resources/favicon.png</Image>
-    <Image height="64" width="64" type="image/png">http://haskell.org/hoogle/datadir/resources/favicon64.png</Image>
+    <Image height="16" width="16" type="image/png">http://haskell.org/hoogle/res/favicon.png</Image>
+    <Image height="64" width="64" type="image/png">http://haskell.org/hoogle/res/favicon64.png</Image>
     <Developer>Neil Mitchell</Developer>
     <AdultContent>false</AdultContent>
     <Language>en-us</Language>


### PR DESCRIPTION
The previous URLs both 404 which results in Firefox picking `haskell.org/favicon.ico` instead which is the same one used for the Hackage search engine, making it difficult to distinguish them.
