### PR TITLE
--hackage flag to attach to a specific hackage server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /dist/
 /datadir/databases/
 Thumbs.db
+.hub

--- a/src/CmdLine/Type.hs
+++ b/src/CmdLine/Type.hs
@@ -28,14 +28,26 @@ data CmdLine
         ,web :: Maybe String
         ,repeat_ :: Int
         ,queryChunks :: [String]
-        
         ,queryParsed :: Either ParseError Query
         ,queryText :: String
         }
-    | Data {redownload :: Bool, rebuild :: Bool, local :: [String], datadir :: FilePath, threads :: Int, actions :: [String]}
+    | Data {
+          hackage    :: String
+        , redownload :: Bool
+        , rebuild :: Bool
+        , local :: [String]
+        , datadir :: FilePath
+        , threads :: Int
+        , actions :: [String]}
     | Server {port :: Int, local_ :: Bool, databases :: [FilePath], resources :: FilePath, dynamic :: Bool, template :: [FilePath]}
     | Combine {srcfiles :: [FilePath], outfile :: String}
-    | Convert {srcfile :: String, outfile :: String, doc :: Maybe String, merge :: [String], haddock :: Bool}
+    | Convert {
+          hackage :: String
+        , srcfile :: String
+        , outfile :: String
+        , doc :: Maybe String
+        , merge :: [String]
+        , haddock :: Bool}
     | Log {logfiles :: [FilePath]}
     | Test {testFiles :: [String], example :: Bool}
     | Dump {database :: String, section :: [String]}
@@ -92,7 +104,8 @@ combine = Combine
     } &= help "Combine multiple databases into one"
 
 convert = Convert
-    {srcfile = def &= argPos 0 &= typ "INPUT"
+    {hackage = "http://hackage.haskell.org" &= typ "URL" &= help "Hackage instance to target"
+    ,srcfile = def &= argPos 0 &= typ "INPUT"
     ,outfile = def &= argPos 1 &= typ "DATABASE" &= opt ""
     ,doc = def &= typDir &= help "Path to the root of local or Hackage documentation for the package (implies --haddock)"
     ,merge = def &= typ "DATABASE" &= help "Merge other databases"
@@ -101,6 +114,7 @@ convert = Convert
 
 data_ = Data
     {datadir = def &= typDir &= help "Database directory"
+    ,hackage    = "http://hackage.haskell.org" &= typ "URL" &= help "Hackage instance to target"
     ,redownload = def &= help "Redownload all files from the web"
     ,rebuild = def &= help "Rebuild everything"
     ,threads = 1 &= typ "INT" &= name "j" &= help "Number of threads to use"

--- a/src/Console/Test.hs
+++ b/src/Console/Test.hs
@@ -26,7 +26,7 @@ testPrepare = do
     createDirectoryIfMissing True $ dat </> "databases"
     src <- readFileUtf8 $ dat </> "testdata.txt"
     let dbfile = dat </> "databases/testdata.hoo"
-    errs <- createDatabase Haskell [] src dbfile
+    errs <- createDatabase "http://hackage.haskell.org" Haskell [] src dbfile
     unless (null errs) $ error $ unlines $ "Couldn't convert testdata database:" : map show errs
     db <- loadDatabase dbfile
     -- this test is now mostly redundant because i can't get the file before saving

--- a/src/Hoogle.hs
+++ b/src/Hoogle.hs
@@ -82,13 +82,14 @@ loadDatabase x = do db <- H.loadDataBase x; return $ Database [(x, db)]
 -- | Create a database from an input definition. Source files for Hoogle databases are usually
 --   stored in UTF8 format, and should be read using 'hSetEncoding' and 'utf8'.
 createDatabase
-    :: H.Language -- ^ Which format the input definition is in.
+    :: H.HackageURL
+    -> H.Language -- ^ Which format the input definition is in.
     -> [Database] -- ^ A list of databases which contain definitions this input definition relies upon (e.g. types, aliases, instances).
     -> String -- ^ The input definitions, usually with one definition per line, in a format specified by the 'Language'.
     -> FilePath -- ^ Output file
     -> IO [H.ParseError] -- ^ A list of any parse errors present in the input definition that were skipped.
-createDatabase _ dbs src out = do
-    let (err,res) = H.parseInputHaskell src
+createDatabase url _ dbs src out = do
+    let (err,res) = H.parseInputHaskell url src
     let xs = concat [map snd x | Database x <- dbs]
     let db = H.createDataBase xs res
     performGC

--- a/src/Hoogle/DataBase/All.hs
+++ b/src/Hoogle/DataBase/All.hs
@@ -1,4 +1,3 @@
-
 module Hoogle.DataBase.All
     (DataBase, showDataBase
     ,module Hoogle.DataBase.All

--- a/src/Hoogle/Type/Item.hs
+++ b/src/Hoogle/Type/Item.hs
@@ -11,6 +11,8 @@ import Hoogle.Type.TypeSig
 import Data.Generics.Uniplate
 
 
+type HackageURL = String
+
 type Input = ([Fact], [TextItem])
 
 data ItemKind = PackageItem


### PR DESCRIPTION
Hi Neil,
as promised, here's the first tentative patch.
The fix for CmdLine was trivial, so was the one for the action, because we had the CmdLine obj in scope.
A bit more problematic and unfortunate was to push to the bottom of the stack the HackageURL (type synonym created just to aid readability) when we need to create databases and thus items for them.
Last but not least, I was forced to expand "Convert" as well, because now the command makes sense only once we specify from which hackage we want to convert.
Thoughts? I wasn't sure of the code style either. Generally, whatever I've modified for the patch I've also tried to 
push it to <= 80 columns, please shout if it's not ok! :)

I haven't run the tests, but I did run "hoogle data" with and without the "-h" flag, observing that hoogle is now trying to fetch data according to the URL specified in the flag.

Thanks!
Alfredo
