### PR TITLE
Updates for QuickCheck 2.7 [Fixes #57]

### DIFF
--- a/hoogle.cabal
+++ b/hoogle.cabal
@@ -1,7 +1,7 @@
 cabal-version:      >= 1.10
 build-type:         Simple
 name:               hoogle
-version:            4.2.29
+version:            4.2.29.1
 license:            BSD3
 license-file:       docs/LICENSE
 category:           Development

--- a/src/Test/BWT_FM.hs
+++ b/src/Test/BWT_FM.hs
@@ -3,7 +3,7 @@
 module Test.BWT_FM(bwt_fm) where
 
 import Test.General
-import Test.QuickCheck
+import Test.QuickCheck hiding ((===))
 import General.BurrowsWheeler
 
 

--- a/src/Test/General.hs
+++ b/src/Test/General.hs
@@ -3,7 +3,7 @@ module Test.General(parseTest, (===), randCheck) where
 
 import Control.Monad
 import qualified Data.ByteString as BS
-import Test.QuickCheck
+import Test.QuickCheck hiding ((===))
 
 
 instance Arbitrary BS.ByteString where


### PR DESCRIPTION
Bumped version number, though a more aggressive bump may be called for due to the apparent API change in QuickCheck.

All tests pass.
