### PR TITLE
Fix escaping for URL fragments (#103)

### DIFF
--- a/src/Action/Search.hs
+++ b/src/Action/Search.hs
@@ -73,3 +73,5 @@ action_search_test = testing "Action.Search.search" $ storeReadFile "output/all.
     "<>" === hackage "base/docs/Data-Monoid.html#v:-60--62-"
     "Data.Set.insert" === hackage "containers/docs/Data-Set.html#v:insert"
     "Set.insert" === hackage "containers/docs/Data-Set.html#v:insert"
+    "Prelude.mapM_" === hackage "base/docs/Prelude.html#v:mapM_"
+    "Data.Complex.(:+)" === hackage "base/docs/Data-Complex.html#v::-43-"

--- a/src/Input/Hoogle.hs
+++ b/src/Input/Hoogle.hs
@@ -107,8 +107,15 @@ heirarchy hackage = list' . map other . with (isIModule . itemItem) . map module
 
         esc = concatMap f
             where
-                f x | isAlphaNum x = [x]
+                f x | isLegal x = [x]
                     | otherwise = "-" ++ show (ord x) ++ "-"
+                -- isLegal is from haddock-api:Haddock.Utils; we need to use
+                -- the same escaping strategy here in order for fragment links
+                -- to work
+                isLegal ':' = True
+                isLegal '_' = True
+                isLegal '.' = True
+                isLegal c = isAscii c && isAlphaNum c
 
 
 parseLine :: Int -> String -> Either String [Item]


### PR DESCRIPTION
Use the same escaping rules that Haddock does, to ensure that links to
specific types or values in Haddock documentation (eg, mapM_, (:+)) work
correctly.