### PR TITLE
Add package search example

### DIFF
--- a/html/welcome.html
+++ b/html/welcome.html
@@ -16,6 +16,7 @@
     <a href="?hoogle=(a%20-&gt;%20b)%20-&gt;%20%5Ba%5D%20-&gt;%20%5Bb%5D">(a -&gt; b) -&gt; [a] -&gt; [b]</a><br/>
     <a href="?hoogle=Ord%20a%20%3D&gt;%20%5Ba%5D%20-&gt;%20%5Ba%5D">Ord a =&gt; [a] -&gt; [a]</a><br/>
     <a href="?hoogle=Data.Set.insert">Data.Set.insert</a><br/>
+    <a href="?hoogle=%2Bbytestring+concat">+bytestring concat</a><br/>
     <br/>Enter your own search at the top of the page.
 </p>
 <p>


### PR DESCRIPTION
Fixes #72 , adds an example search for "+bytestring concat" on the welcome page.