### PR TITLE
fixed URL for "keywords"

### DIFF
--- a/datadir/examples.txt
+++ b/datadir/examples.txt
@@ -10,7 +10,7 @@ keyword ~
 
 -- check that keyword links work, bug #309
 ! --link +keyword -n1
-keyword ! -- http://haskell.org/haskellwiki/Keywords#.21
+keyword ! -- http://wiki.haskell.org/Keywords#.21
 
 -- check you find forall, bug #235
 forall -n10

--- a/src/Recipe/All.hs
+++ b/src/Recipe/All.hs
@@ -180,7 +180,7 @@ rules opts@Data{..} warn = do
 
 urls :: C.CmdLine -> [(FilePath, URL)]
 urls Data{..} = let (*) = (,) in
-    ["keyword.htm" * "http://www.haskell.org/haskellwiki/Keywords"
+    ["keyword.htm" * "http://wiki.haskell.org/Keywords"
     ,"platform.cabal" * "http://code.galois.com/darcs/haskell-platform/haskell-platform.cabal"
     ,"base.txt" * "http://www.haskell.org/hoogle/base.txt"
     ,"cabal.tar.gz" * (hackage ++ "packages/index.tar.gz")

--- a/src/Recipe/Keyword.hs
+++ b/src/Recipe/Keyword.hs
@@ -16,7 +16,7 @@ keywordPrefix =
     ,"-- See Hoogle, http://www.haskell.org/hoogle/"
     ,""
     ,"-- | Haskell keywords, always available"
-    ,"@url http://haskell.org/haskellwiki/Keywords"
+    ,"@url http://wiki.haskell.org/Keywords"
     ,"@package keyword"
     ]
 


### PR DESCRIPTION
Changed the URL for "keywords" from http://www.haskell.org/haskellwiki/Keywords to http://wiki.haskell.org/Keywords in order to fix "hoogle data".