### PR TITLE
allow https:// protocol for links

### DIFF
--- a/src/Console/All.hs
+++ b/src/Console/All.hs
@@ -53,7 +53,11 @@ action (Convert url from to doc merge haddock) = do
                           else id
 
       addDoc :: Maybe FilePath -> Maybe URL
-      addDoc = addGhcDoc . fmap (\x -> if "http://" `isPrefixOf` x then x else filePathToURL $ x </> "index.html")
+      addDoc = addGhcDoc . fmap toURL
+      toURL x | "http://" `isPrefixOf` x
+             || "https://" `isPrefixOf` x
+             || "file://" `isPrefixOf` x = x
+      toURL x = filePathToURL $ x </> "index.html"
 
       addGhcDoc :: Maybe URL -> Maybe URL
       addGhcDoc x = if isNothing x && takeBaseName from == "ghc"


### PR DESCRIPTION
the --doc flag for convert is a little weird; it only supports http:// (and not https://) and for files it adds an extra /index.html
later, the code for showing the links strips everything from the last slash so if it's a file, we're supposed to put in the directory (since /index.html is added automatically), but for http, we're supposed to put the whole filepath (including index.html?) ... or spend some time tinkering to reverse engineer this and then add an extra slash at the end so nothing is stripped...

test plan:
```
> hoogle convert default.txt -d "file://foo/bar/"
> hoogle search -l a
Mod a :: Int -- file://foo/bar/Mod.html#v:a

> hoogle convert default.txt -d "foo/bar"
> hoogle search -l a
Mod a :: Int -- file:///foo/bar/Mod.html#v:a

> hoogle convert default.txt -d "http://foo.com/"
> hoogle search -l a
Mod a :: Int -- http://foo.com/Mod.html#v:a

> hoogle convert default.txt -d "https://foo.com/"
> hoogle search -l a
Mod a :: Int -- https://foo.com/Mod.html#v:a
```

i would even go on further and remove the `</> "index.html"` but i guess i don't really want to change the behaviour and break other people's stuff...
afaik, generating from an individual source text file is not supported yet in hoogle5, so for now i'm fixing it in 4...