### PR TITLE
add option to run hoogle server over TLS

### DIFF
--- a/hoogle.cabal
+++ b/hoogle.cabal
@@ -151,6 +151,7 @@ executable hoogle
         parsec >= 2.1,
         wai >= 1.1,
         warp >= 2.1,
+        warp-tls,
         Cabal >= 1.8,
         shake >= 0.14,
         QuickCheck,

--- a/src/CmdLine/Type.hs
+++ b/src/CmdLine/Type.hs
@@ -18,18 +18,18 @@ isWebCmdLine _ = False
 
 data CmdLine
     = Search
-        {color :: Bool
-        ,link :: Bool
-        ,info :: Bool
-        ,exact :: Bool
-        ,databases :: [FilePath]
-        ,start :: Maybe Int
-        ,count :: Maybe Int
-        ,web :: Maybe String
-        ,repeat_ :: Int
-        ,queryChunks :: [String]
-        ,queryParsed :: Either ParseError Query
-        ,queryText :: String
+        { color :: Bool
+        , link :: Bool
+        , info :: Bool
+        , exact :: Bool
+        , databases :: [FilePath]
+        , start :: Maybe Int
+        , count :: Maybe Int
+        , web :: Maybe String
+        , repeat_ :: Int
+        , queryChunks :: [String]
+        , queryParsed :: Either ParseError Query
+        , queryText :: String
         }
     | Data {
           hackage    :: String
@@ -41,7 +41,17 @@ data CmdLine
         , actions :: [String]
         , nodownload :: Bool
         }
-    | Server {port :: Int, local_ :: Bool, databases :: [FilePath], resources :: FilePath, dynamic :: Bool, template :: [FilePath]}
+    | Server {
+          port :: Int
+        , local_ :: Bool
+        , databases :: [FilePath]
+        , resources :: FilePath
+        , dynamic :: Bool
+        , template :: [FilePath]
+        , https :: Bool
+        , cert :: FilePath
+        , key :: FilePath
+        }
     | Combine {srcfiles :: [FilePath], outfile :: String}
     | Convert {
           hackage :: String
@@ -89,6 +99,9 @@ server = Server
     ,local_ = def &= help "Rewrite and serve file: links (potential security hole)"
     ,dynamic = def &= name "x" &= help "Allow resource files to change during execution"
     ,template = def &= typFile &= help "Template files to use instead of default definitions"
+    ,https = def &= help "Start an https server (use --cert and --key to specify paths to the .pem files)"
+    ,cert = "cert.pem" &= typFile &= help "Path to the certificate pem file (when running an https server)"
+    ,key = "key.pem" &= typFile &= help "Path to the key pem file (when running an https server)"
     } &= help "Start a Hoogle server"
 
 dump = Dump

--- a/src/Web/Server.hs
+++ b/src/Web/Server.hs
@@ -26,6 +26,7 @@ import Network.Wai
 import Network.Wai.Internal
 #endif
 import Network.Wai.Handler.Warp
+import Network.Wai.Handler.WarpTLS
 
 
 server :: CmdLine -> IO ()
@@ -33,7 +34,12 @@ server q@Server{..} = do
     resp <- respArgs q
     v <- newMVar ()
     putStrLn $ "Starting Hoogle Server on port " ++ show port
-    runSettings (setOnException exception $ setPort port defaultSettings)
+    let
+        settings = (setOnException exception $ setPort port defaultSettings)
+        runServer :: Application -> IO ()
+        runServer = if https then runTLS (tlsSettings cert key) settings
+                             else runSettings settings
+    runServer
 #if MIN_VERSION_wai(3, 0, 0)
       $ \r sendResponse -> do
 #else


### PR DESCRIPTION
`hoogle server --https --cert="my_cert.pem" --key="my_key.pem"` serves the hoogle pages over TLS

tested with a self-generated certificate:
![screen shot 2016-02-22 at 4 38 43 pm](https://cloud.githubusercontent.com/assets/733205/13225317/33bb1e62-d984-11e5-9e5d-659238a82aa6.png)

* are we worried about pulling in this dependency?
* i have no idea whether this depends on particular versions of some packages
* if this is useful, i can also modify hoogle5 to support https