### PR TITLE
enable support for IPv6

### DIFF
--- a/src/CmdLine/Type.hs
+++ b/src/CmdLine/Type.hs
@@ -51,6 +51,7 @@ data CmdLine
         , https :: Bool
         , cert :: FilePath
         , key :: FilePath
+        , host :: String
         }
     | Combine {srcfiles :: [FilePath], outfile :: String}
     | Convert {
@@ -102,6 +103,7 @@ server = Server
     ,https = def &= help "Start an https server (use --cert and --key to specify paths to the .pem files)"
     ,cert = "cert.pem" &= typFile &= help "Path to the certificate pem file (when running an https server)"
     ,key = "key.pem" &= typFile &= help "Path to the key pem file (when running an https server)"
+    ,host = "*" &= help "Set the host to bind on (e.g., an ip address; '!4' for ipv4-only; '!6' for ipv6-only; default: '*' for any host)."
     } &= help "Start a Hoogle server"
 
 dump = Dump

--- a/src/Web/Server.hs
+++ b/src/Web/Server.hs
@@ -35,7 +35,9 @@ server q@Server{..} = do
     v <- newMVar ()
     putStrLn $ "Starting Hoogle Server on port " ++ show port
     let
-        settings = (setOnException exception $ setPort port defaultSettings)
+        settings = setOnException exception $
+                   setHost (fromString host) $
+                   setPort port defaultSettings
         runServer :: Application -> IO ()
         runServer = if https then runTLS (tlsSettings cert key) settings
                              else runSettings settings


### PR DESCRIPTION
![screen shot 2016-02-23 at 2 18 28 pm](https://cloud.githubusercontent.com/assets/733205/13254932/85f58796-da3b-11e5-8162-d7fbef31845c.png)

again, i'll make sure i port this also to hoogle5
i also tried an ipv6-only option but when testing it ("!6"), hoogle was still accessible via ipv4 - i'm not sure whether that's a bug in some of the networking libraries...