### PR TITLE
WIP: Fix file links on *nix

### DIFF
--- a/src/Action/Server.hs
+++ b/src/Action/Server.hs
@@ -115,7 +115,7 @@ replyServer log local store cdn htmlDir scope = \Input{..} -> case inputURL of
          else
             return $ OutputFail $ lstrPack "GHC Statistics is not enabled, restart with +RTS -T"
     "file":xs | local -> do
-        let x = intercalate "/" xs
+        let x = "/" ++ intercalate "/" xs
         return $ OutputFile $ x ++ (if hasTrailingPathSeparator x then "index.html" else "")
     xs ->
         -- avoid "" and ".." in the URLs, since they could be trying to browse on the server


### PR DESCRIPTION
NB: I have a feeling this is the wrong total solution, since I suspect it
will break Windows paths.

What this *does* accomplish is make file urls work when running the server
in 'local' mode. (On Linux.) Without this patch, all `/file/...` routes returned 'File not found'.