### PR TITLE
Use a recursive directory traversal in generate

### DIFF
--- a/src/Action/Generate.hs
+++ b/src/Action/Generate.hs
@@ -128,7 +128,7 @@ readHaskellOnline timing settings download = do
 
 readHaskellDir :: Timing -> FilePath -> IO (Map.Map String Package, Set.Set String, Source IO (String, URL, LStr))
 readHaskellDir timing dir = do
-    packages <- map (takeBaseName &&& id) . filter ((==) ".txt" . takeExtension) <$> listFiles dir
+    packages <- map (takeBaseName &&& id) . filter ((==) ".txt" . takeExtension) <$> listFilesRecursive dir
     let source = forM_ packages $ \(name, file) -> do
             src <- liftIO $ strReadFile file
             yield (name, hackagePackageURL name, lstrFromChunks [src])


### PR DESCRIPTION
At least in the case of Nix---which has a function to automatically create a hoogle index for the libraries it's in the process of installing for you (which means you can't use `ghc-pkg list`)---it is helpful to be able to have hoogle recurse through a directory (which is actually a symlink farm to the documentation directories of the various libraries) looking for .txt files, rather than just looking shallowly.