### PR TITLE
Allow indexing multiple local packages

### DIFF
--- a/src/Action/CmdLine.hs
+++ b/src/Action/CmdLine.hs
@@ -35,7 +35,7 @@ data CmdLine
         ,database :: FilePath
         ,insecure :: Bool
         ,include :: [String]
-        ,local_ :: Maybe FilePath
+        ,local_ :: [Maybe FilePath]
         ,debug :: Bool
         ,language :: Language
         }

--- a/src/Action/Test.hs
+++ b/src/Action/Test.hs
@@ -28,7 +28,7 @@ actionTest Test{..} = withBuffering stdout NoBuffering $ withTempFile $ \sample 
     putStrLn ""
 
     putStrLn "Sample database tests"
-    actionGenerate defaultGenerate{database=sample, local_=Just "misc/sample-data"}
+    actionGenerate defaultGenerate{database=sample, local_=[Just "misc/sample-data"]}
     action_search_test True sample
     action_server_test True sample
     putStrLn ""


### PR DESCRIPTION
Patch generate command to accept the `--local' flag more than once, hence enabling Hoogle to generate docs for more than one packages at same database.

Note that with this patch, passing `--local <dir1> --local --local <dir2>` is allowed, and will fail with
```bash
hoogle: : getDirectoryContents: does not exist (No such file or directory)
```

This is not optimal, but it was done in Debian in order to keep backward compatibility (i.e., support both `--local` and `--local <dir>` as before). We could probably create a new flag, namely `--ghc-pkg` and drop the empty `--local` one. What do you think?

Closes #192: Allow indexing multiple local packages