### PR TITLE
Added `--home` flag to `server` command

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -23,7 +23,7 @@
     </ul>
 </div>
 <form action="." method="get" id="search">
-    <a id="logo" href="http://hoogle.haskell.org">
+    <a id="logo" href="#{home}">
         <img src="#{cdn}hoogle.png" width="160" height="58" alt="Hoogle"
     /></a>
     <input name="hoogle" id="hoogle" class="HOOGLE_REAL" type="text" autocomplete="off" accesskey="1" placeholder="Search for..." value="#{search}" />

--- a/src/Action/CmdLine.hs
+++ b/src/Action/CmdLine.hs
@@ -47,6 +47,7 @@ data CmdLine
         ,local :: Bool
         ,language :: Language
         ,scope :: String
+        ,home :: String
         ,host :: String
         ,https :: Bool
         ,cert :: FilePath
@@ -120,6 +121,7 @@ server = Server
     ,logs = "" &= opt "log.txt" &= typFile &= help "File to log requests to (defaults to stdout)"
     ,local = False &= help "Allow following file:// links, restricts to 127.0.0.1  Set --host explicitely (including to '*' for any host) to override the localhost-only behaviour"
     ,scope = def &= help "Default scope to start with"
+    ,home = "" &= typ "URL" &= help "Set the URL linked to by the Hoogle logo."
     ,host = "" &= help "Set the host to bind on (e.g., an ip address; '!4' for ipv4-only; '!6' for ipv6-only; default: '*' for any host)."
     ,https = def &= help "Start an https server (use --cert and --key to specify paths to the .pem files)"
     ,cert = "cert.pem" &= typFile &= help "Path to the certificate pem file (when running an https server)"


### PR DESCRIPTION
This adds a new `--home` flag, which allows you to specify the URL
linked to by the Hoogle logo in the upper left of every page.

This ameliorates the following frustrating scenario:

1. Launch `hoogle -p 8080 --local` (or similar)
2. Navigate to localhost:8080
3. Search for `foo` with your local Hoogle instance
4. You found what you want, so you instinctively click the Hoogle logo
   in the upper left to get back to the home page.
5. Now you're at hoogle.haskell.org rather than localhost:8080
6. Either you notice, in which case you have to navigate back to your
   local instance, or you don't notice, in which case you get very
   confused as none of your local packages show up in search results.