### PR TITLE
Correct output semantics for the search server

### DIFF
--- a/src/Action/Server.hs
+++ b/src/Action/Server.hs
@@ -85,14 +85,14 @@ replyServer log local store cdn home htmlDir scope = \Input{..} -> case inputURL
         let (q2, results) = search store q
         let body = showResults local inputArgs q2 $ dedupeTake 25 (\t -> t{targetURL="",targetPackage=Nothing, targetModule=Nothing}) results
         case lookup "mode" $ reverse inputArgs of
-            Nothing | qSource /= [] -> fmap OutputString $ templateRender templateIndex $ map (second str)
+            Nothing | qSource /= [] -> fmap OutputHTML $ templateRender templateIndex $ map (second str)
                         [("tags",tagOptions qScope)
                         ,("body",body)
                         ,("title",unwords qSource ++ " - Hoogle")
                         ,("search",unwords $ grab "hoogle")
                         ,("robots",if any isQueryScope q then "none" else "index")]
-                    | otherwise -> OutputString <$> templateRender templateHome []
-            Just "body" -> OutputString <$> if null qSource then templateRender templateEmpty [] else return $ lstrPack body
+                    | otherwise -> OutputHTML <$> templateRender templateHome []
+            Just "body" -> OutputHTML <$> if null qSource then templateRender templateEmpty [] else return $ lstrPack body
             Just "json" -> return $ OutputJSON $ JSON.encode $ take 100 results
             Just m -> return $ OutputFail $ lstrPack $ "Mode " ++ m ++ " not (currently) supported"
     ["plugin","jquery.js"] -> OutputFile <$> JQuery.file


### PR DESCRIPTION
Fixes #200.

It looks like the code in `Action.Server` has bit-rotten and it wasn't using the correct types for output. It was using a plain `OutputString` whereas `OutputHTML` would have been more appropriate at it causes the web server to send the appropriate `Content-Type`. I've changed those, which fixed the issue with text-browsers that I was seeing. 

I didn't touch the `OutputString` in the stats handler as I was not sure about the intended semantics of the output. It might be worth checking it and also searching for other occurrences of `OutputString` and checking if a more specific constructor (e.g. OutputHTML or OutputJSON) would be more appropriate.