### PR TITLE
Support for a portable haddocks directory when indexing local projects

### DIFF
--- a/src/Action/CmdLine.hs
+++ b/src/Action/CmdLine.hs
@@ -36,6 +36,7 @@ data CmdLine
         ,insecure :: Bool
         ,include :: [String]
         ,local_ :: [FilePath]
+        ,haddock_ :: Maybe FilePath
         ,debug :: Bool
         ,language :: Language
         }
@@ -45,6 +46,7 @@ data CmdLine
         ,cdn :: String
         ,logs :: FilePath
         ,local :: Bool
+        ,haddock :: Maybe FilePath
         ,language :: Language
         ,scope :: String
         ,home :: String
@@ -112,6 +114,7 @@ generate = Generate
     ,insecure = def &= help "Allow insecure HTTPS connections"
     ,include = def &= args &= typ "PACKAGE"
     ,local_ = def &= opt "" &= help "Index local packages"
+    ,haddock_ = def &= help "Use local haddocks"
     ,debug = def &= help "Generate debug information"
     } &= help "Generate Hoogle databases"
 
@@ -120,6 +123,7 @@ server = Server
     ,cdn = "" &= typ "URL" &= help "URL prefix to use"
     ,logs = "" &= opt "log.txt" &= typFile &= help "File to log requests to (defaults to stdout)"
     ,local = False &= help "Allow following file:// links, restricts to 127.0.0.1  Set --host explicitely (including to '*' for any host) to override the localhost-only behaviour"
+    ,haddock = def &= help "Serve local haddocks from a specified directory"
     ,scope = def &= help "Default scope to start with"
     ,home = "http://hoogle.haskell.org" &= typ "URL" &= help "Set the URL linked to by the Hoogle logo."
     ,host = "" &= help "Set the host to bind on (e.g., an ip address; '!4' for ipv4-only; '!6' for ipv6-only; default: '*' for any host)."


### PR DESCRIPTION
* `hoogle generate --haddock=path/to/doc` works similarly to `hoogle generate --local`, getting package info from a local ghc-pkg database, but uses `path/to/doc` as the canonical source of Haddock documentation. `path/to/doc` should be a path to the directory that contains the root `index.html` generated by `cabal haddock` or `stack haddock`. Paths stored in the database are relative to this root.

* `hoogle server --haddock=path/to/doc` is intended to be used with a database containing relative paths. In contrast to `hoogle server --local`, paths relative to the filesystem root are not allowed; only files from `path/to/doc` are served.

These features are intended to be used together, when you want to create a Hoogle index for your project in one place, then serve it somewhere else. This enables a workflow such as the following:

1. Run `cabal haddock` or `stack haddock` on your build server
2. Run `hoogle generate --haddock=path/to/doc` on your build server (this assumes you know where the docs were written)
3. Deploy the Hoogle database and Haddock files to your documentation server & run `hoogle server --haddock=new/path/to/doc`
5. ???
6. Profit