### PR TITLE
Don't output results when specified module/package/category not found in db.

### DIFF
--- a/src/Action/Search.hs
+++ b/src/Action/Search.hs
@@ -22,8 +22,6 @@ import Query
 import Input.Item
 import Action.CmdLine
 import General.Util
-import Debug.Trace
-
 
 -- -- generate all
 -- @tagsoup -- generate tagsoup
@@ -81,8 +79,8 @@ withSearch database act = do
 
 search :: StoreRead -> [Query] -> ([Query], [Target])
 search store qs = runIdentity $ do
-    (qs, exact, filt, list) <- return $ applyTags store $ traceShowId qs
-    is <- case (filter isQueryName qs, filter isQueryType $ traceShowId qs) of
+    (qs, exact, filt, list) <- return $ applyTags store  qs
+    is <- case (filter isQueryName qs, filter isQueryType qs) of
         ([], [] ) -> return list
         ([], t:_) -> return $ searchTypes store $ hseToSig $ fromQueryType t
         (xs, [] ) -> return $ searchNames store exact $ map fromQueryName xs

--- a/src/Output/Tags.hs
+++ b/src/Output/Tags.hs
@@ -151,17 +151,17 @@ filterTags ts qs = (map redo qs, exact, \i -> all ($ i) fs)
 
 filterTags2 ts qs = \i -> not (negq i) && (noPosRestrict || posq i)
     where (posq,negq) = both inRanges (pos,neg)
-          (pos, neg) = both (map snd) $ partition fst xs
-          xs = concat $ catMaybes restrictions
-          restrictions = map getRestriction qs
+          (pos, neg) = both (concatMap snd) $ partition fst xs
+          xs = catMaybes restrictions
           noPosRestrict = all pred restrictions
+          restrictions = map getRestriction qs
           pred Nothing = True
-          pred (Just xs') = all (not . fst) xs'
-          getRestriction :: Query -> Maybe [(Bool,(TargetId, TargetId))]
+          pred (Just (sense, _)) = not sense
+          getRestriction :: Query -> Maybe (Bool,[(TargetId, TargetId)])
           getRestriction (QueryScope sense cat val) = do
             tag <- parseTag cat val
             ranges <- snd $ resolveTag ts tag
-            return $ map (sense,) ranges
+            return (sense, ranges)
 
 
 -- | Given a search which has no type or string in it, run the query on the tag bits.

--- a/src/Output/Tags.hs
+++ b/src/Output/Tags.hs
@@ -144,7 +144,7 @@ filterTags ts qs = (map redo qs, exact, \i -> all ($ i) fs)
     where fs = map (filterTags2 ts . snd) $ groupSort $ map (scopeCategory &&& id) $ filter isQueryScope qs
           exact = Just IsExact `elem` [parseTag a b | QueryScope True a b <- qs]
           redo (QueryScope sense cat val)
-              | Just (k,v) <- fmap showTag $ fst . resolveTag ts <$> parseTag cat val = QueryScope sense k v
+              | Just (k,v) <- fmap (showTag . fst . resolveTag ts) $ parseTag cat val = QueryScope sense k v
               | otherwise = QueryNone $ ['-' | not sense] ++ cat ++ ":" ++ val
           redo q = q
 

--- a/src/Output/Tags.hs
+++ b/src/Output/Tags.hs
@@ -113,7 +113,7 @@ resolveTag store x = case x of
     EqPackage orig@(BS.pack -> val)
         -- look for people who are an exact prefix, sort by remaining length, if there are ties, pick the first one
         | res@(_:_) <- [(BS.length x, (i,x)) | (i,x) <- zip [0..] $ split0 packageNames, val `BS.isPrefixOf` x]
-            -> let (i,x) = snd $ minimumBy (compare `on` fst) res in (EqPackage $ BS.unpack x, Just $ [packageIds V.! i])
+            -> let (i,x) = snd $ minimumBy (compare `on` fst) res in (EqPackage $ BS.unpack x, Just [packageIds V.! i])
         | otherwise -> (EqPackage orig , Just [])
     EqModule x -> (EqModule x, Just $ map (moduleIds V.!) $ findIndices (eqModule $ lower x) $ split0 moduleNames)
     EqCategory cat val -> (EqCategory cat val, Just $ concat

--- a/src/Output/Tags.hs
+++ b/src/Output/Tags.hs
@@ -149,12 +149,14 @@ filterTags ts qs = (map redo qs, exact, \i -> all ($ i) fs)
           redo q = q
 
 
-filterTags2 ts qs = \i -> not (negq i) && (noRestrict || posq i)
+filterTags2 ts qs = \i -> not (negq i) && (noPosRestrict || posq i)
     where (posq,negq) = both inRanges (pos,neg)
           (pos, neg) = both (map snd) $ partition fst xs
           xs = concat $ catMaybes restrictions
           restrictions = map getRestriction qs
-          noRestrict = all isNothing restrictions
+          noPosRestrict = all pred restrictions
+          pred Nothing = True
+          pred (Just xs') = all (not . fst) xs'
           getRestriction :: Query -> Maybe [(Bool,(TargetId, TargetId))]
           getRestriction (QueryScope sense cat val) = do
             tag <- parseTag cat val

--- a/src/Output/Tags.hs
+++ b/src/Output/Tags.hs
@@ -109,7 +109,7 @@ resolveTag store x = case x of
     IsExact -> (Just IsExact, [])
     IsPackage -> (Just IsPackage, map (dupe . fst) $ V.toList packageIds)
     IsModule -> (Just IsModule, map (dupe . fst) $ V.toList moduleIds)
-    EqPackage (BS.pack . lower -> val)
+    EqPackage (BS.pack -> val)
         -- look for people who are an exact prefix, sort by remaining length, if there are ties, pick the first one
         | res@(_:_) <- [(BS.length x, (i,x)) | (i,x) <- zip [0..] $ split0 packageNames, val `BS.isPrefixOf` x]
             -> let (i,x) = snd $ minimumBy (compare `on` fst) res in (Just $ EqPackage $ BS.unpack x, [packageIds V.! i])

--- a/src/Output/Tags.hs
+++ b/src/Output/Tags.hs
@@ -103,19 +103,20 @@ showTag (EqCategory k v) = (k,v)
 ---------------------------------------------------------------------
 -- TAG SEMANTICS
 
--- | Given a tag, find the ranges of identifiers it covers
-resolveTag :: StoreRead -> Tag -> (Maybe Tag, [(TargetId,TargetId)])
+-- | Given a tag, find the ranges of identifiers it covers(if it restricts the range)
+-- An empty range means an empty result, while a Nothing means a search on the entire range
+resolveTag :: StoreRead -> Tag -> (Tag, Maybe [(TargetId,TargetId)])
 resolveTag store x = case x of
-    IsExact -> (Just IsExact, [])
-    IsPackage -> (Just IsPackage, map (dupe . fst) $ V.toList packageIds)
-    IsModule -> (Just IsModule, map (dupe . fst) $ V.toList moduleIds)
-    EqPackage (BS.pack -> val)
+    IsExact -> (IsExact, Nothing)
+    IsPackage -> (IsPackage, Just $ map (dupe . fst) $ V.toList packageIds)
+    IsModule -> (IsModule, Just $ map (dupe . fst) $ V.toList moduleIds)
+    EqPackage orig@(BS.pack -> val)
         -- look for people who are an exact prefix, sort by remaining length, if there are ties, pick the first one
         | res@(_:_) <- [(BS.length x, (i,x)) | (i,x) <- zip [0..] $ split0 packageNames, val `BS.isPrefixOf` x]
-            -> let (i,x) = snd $ minimumBy (compare `on` fst) res in (Just $ EqPackage $ BS.unpack x, [packageIds V.! i])
-        | otherwise -> (Nothing, [])
-    EqModule x -> (Just $ EqModule x, map (moduleIds V.!) $ findIndices (eqModule $ lower x) $ split0 moduleNames)
-    EqCategory cat val -> (Just $ EqCategory cat val, concat
+            -> let (i,x) = snd $ minimumBy (compare `on` fst) res in (EqPackage $ BS.unpack x, Just $ [packageIds V.! i])
+        | otherwise -> (EqPackage orig , Just [])
+    EqModule x -> (EqModule x, Just $ map (moduleIds V.!) $ findIndices (eqModule $ lower x) $ split0 moduleNames)
+    EqCategory cat val -> (EqCategory cat val, Just $ concat
         [ V.toList $ jaggedAsk categoryIds i
         | i <- elemIndices (BS.pack (cat ++ ":" ++ val)) $ split0 categoryNames])
     where
@@ -143,21 +144,28 @@ filterTags ts qs = (map redo qs, exact, \i -> all ($ i) fs)
     where fs = map (filterTags2 ts . snd) $ groupSort $ map (scopeCategory &&& id) $ filter isQueryScope qs
           exact = Just IsExact `elem` [parseTag a b | QueryScope True a b <- qs]
           redo (QueryScope sense cat val)
-              | Just (k,v) <- fmap showTag $ fst . resolveTag ts =<< parseTag cat val = QueryScope sense k v
+              | Just (k,v) <- fmap showTag $ fst . resolveTag ts <$> parseTag cat val = QueryScope sense k v
               | otherwise = QueryNone $ ['-' | not sense] ++ cat ++ ":" ++ val
           redo q = q
 
 
-filterTags2 ts qs = \i -> not (negq i) && (null pos || posq i)
+filterTags2 ts qs = \i -> not (negq i) && (noRestrict || posq i)
     where (posq,negq) = both inRanges (pos,neg)
-          (pos, neg) = both (map snd) $ partition fst $ concatMap f qs
-          f (QueryScope sense cat val) = map (sense,) $ maybe [] (snd . resolveTag ts) $ parseTag cat val
+          (pos, neg) = both (map snd) $ partition fst xs
+          xs = concat $ catMaybes restrictions
+          restrictions = map getRestriction qs
+          noRestrict = all isNothing restrictions
+          getRestriction :: Query -> Maybe [(Bool,(TargetId, TargetId))]
+          getRestriction (QueryScope sense cat val) = do
+            tag <- parseTag cat val
+            ranges <- snd $ resolveTag ts tag
+            return $ map (sense,) ranges
 
 
 -- | Given a search which has no type or string in it, run the query on the tag bits.
 --   Using for things like IsModule, EqCategory etc.
 searchTags :: StoreRead -> [Query] -> [TargetId]
 searchTags ts qs
-    | x:xs <- [map fst $ maybe [] (snd . resolveTag ts) $ parseTag cat val | QueryScope True cat val <- qs]
+    | x:xs <- [map fst $ maybe [] (fromMaybe [] . snd . resolveTag ts) $ parseTag cat val | QueryScope True cat val <- qs]
     = if null xs then x else filter (`Set.member` foldl1' Set.intersection (map Set.fromList xs)) x
-searchTags ts _ = map fst $ snd $ resolveTag ts IsPackage
+searchTags ts _ = map fst $ fromMaybe [] $  snd $ resolveTag ts IsPackage

--- a/src/Output/Tags.hs
+++ b/src/Output/Tags.hs
@@ -103,7 +103,7 @@ showTag (EqCategory k v) = (k,v)
 ---------------------------------------------------------------------
 -- TAG SEMANTICS
 
--- | Given a tag, find the ranges of identifiers it covers(if it restricts the range)
+-- | Given a tag, find the ranges of identifiers it covers (if it restricts the range)
 -- An empty range means an empty result, while a Nothing means a search on the entire range
 resolveTag :: StoreRead -> Tag -> (Tag, Maybe [(TargetId,TargetId)])
 resolveTag store x = case x of


### PR DESCRIPTION
Issue described in #215 

Also fixes a bug where package names with upper case letters(QuickCheck, HaRe etc.) wouldn't be found in the db.