### PR TITLE
start hoogle on non privilege port by default

### DIFF
--- a/src/Action/CmdLine.hs
+++ b/src/Action/CmdLine.hs
@@ -124,7 +124,7 @@ generate = Generate
     } &= help "Generate Hoogle databases"
 
 server = Server
-    {port = 80 &= typ "INT" &= help "Port number"
+    {port = 8080 &= typ "INT" &= help "Port number"
     ,cdn = "" &= typ "URL" &= help "URL prefix to use"
     ,logs = "" &= opt "log.txt" &= typFile &= help "File to log requests to (defaults to stdout)"
     ,local = False &= help "Allow following file:// links, restricts to 127.0.0.1  Set --host explicitely (including to '*' for any host) to override the localhost-only behaviour"


### PR DESCRIPTION
starting the webserver on a non privilege port is a sensible default for most applications, allows to execute hoogle as non root user without further ado