### PR TITLE
Escape apostrophes in `escapeHTML`

### DIFF
--- a/src/General/Util.hs
+++ b/src/General/Util.hs
@@ -156,6 +156,7 @@ escapeHTML = concatMap f
         f '>' = "&gt;"
         f '&' = "&amp;"
         f '\"' = "&quot;"
+        f '\'' = "&apos;"
         f  x  = [x]
 
 -- | Only guarantees to be the inverse of escapeHTML


### PR DESCRIPTION
Without this, searching for things containing apostrophes is broken in the web interface since the markup in the links on the left breaks. Searching for `foldl`, waiting until the results are loaded and then typing `'` can reproduce this problem.