### PR TITLE
Command flag for overriding data directory in servers

### DIFF
--- a/src/Action/CmdLine.hs
+++ b/src/Action/CmdLine.hs
@@ -55,7 +55,7 @@ data CmdLine
         ,https :: Bool
         ,cert :: FilePath
         ,key :: FilePath
-        ,resrc :: Maybe FilePath
+        ,datadir :: Maybe FilePath
         }
     | Replay
         {logs :: FilePath
@@ -136,7 +136,7 @@ server = Server
     ,https = def &= help "Start an https server (use --cert and --key to specify paths to the .pem files)"
     ,cert = "cert.pem" &= typFile &= help "Path to the certificate pem file (when running an https server)"
     ,key = "key.pem" &= typFile &= help "Path to the key pem file (when running an https server)"
-    ,resrc = def &= help "Override data directory paths"
+    ,datadir = def &= help "Override data directory paths"
     } &= help "Start a Hoogle server"
 
 replay = Replay

--- a/src/Action/CmdLine.hs
+++ b/src/Action/CmdLine.hs
@@ -55,6 +55,7 @@ data CmdLine
         ,https :: Bool
         ,cert :: FilePath
         ,key :: FilePath
+        ,resrc :: Maybe FilePath
         }
     | Replay
         {logs :: FilePath
@@ -135,6 +136,7 @@ server = Server
     ,https = def &= help "Start an https server (use --cert and --key to specify paths to the .pem files)"
     ,cert = "cert.pem" &= typFile &= help "Path to the certificate pem file (when running an https server)"
     ,key = "key.pem" &= typFile &= help "Path to the key pem file (when running an https server)"
+    ,resrc = def &= help "Override data directory paths"
     } &= help "Start a Hoogle server"
 
 replay = Replay

--- a/src/Action/Server.hs
+++ b/src/Action/Server.hs
@@ -54,7 +54,9 @@ actionServer cmd@Server{..} = do
         \x -> "hoogle=" `isInfixOf` x && not ("is:ping" `isInfixOf` x)
     putStrLn . showDuration =<< time
     evaluate spawned
-    dataDir <- getDataDir
+    dataDir <- case resrc of
+      Just d -> return d
+      Nothing -> getDataDir
     haddock <- maybe (return Nothing) (fmap Just . canonicalizePath) haddock
     withSearch database $ \store ->
         server log cmd $ replyServer log local haddock store cdn home (dataDir </> "html") scope

--- a/src/Action/Server.hs
+++ b/src/Action/Server.hs
@@ -54,9 +54,9 @@ actionServer cmd@Server{..} = do
         \x -> "hoogle=" `isInfixOf` x && not ("is:ping" `isInfixOf` x)
     putStrLn . showDuration =<< time
     evaluate spawned
-    dataDir <- case resrc of
-      Just d -> return d
-      Nothing -> getDataDir
+    dataDir <- case datadir of
+        Just d -> return d
+        Nothing -> getDataDir
     haddock <- maybe (return Nothing) (fmap Just . canonicalizePath) haddock
     withSearch database $ \store ->
         server log cmd $ replyServer log local haddock store cdn home (dataDir </> "html") scope


### PR DESCRIPTION
Building a binary that contains a hoogle server has hard-coded paths embedded in the binary. When deploying this binary to other machines, the full paths generated from `Paths_hoogle` may not exist. This provides a command line override for the location of the local resources.