### PR TITLE
[#123] Fix search plugin setup.

### DIFF
--- a/html/hoogle.js
+++ b/html/hoogle.js
@@ -251,7 +251,9 @@ $(function(){
 function searchPlugin()
 {
     var url = $("link[rel=search]").attr("href");
-    if (url.indexOf('://') === -1 || url.indexOf('//') !== 0 )
+    //  If neither scheme(http(s)://) nor DSN prefix(//) is in URL then we
+    //  should add prefix.
+    if (url.indexOf('://') === -1 && url.indexOf('//') !== 0)
         url = prefixUrl + url;
     window.external.AddSearchProvider(url);
 }


### PR DESCRIPTION
Here I fix search plugin installation. It  It did not work correctly since URI to OpenSearch descriptor and prefix URl were concatenated in wrong way. The conditions to add prefix to URI is a bit messy so here I provide some details about issue. There are a three kinds of URLs they are

1. schemafull URLs like `https://hoohle.haskell.org/some/uri/here` (`://` is in)
2. schemaless URLs like `//git.dsn/some/uri/here` (`//` is the prefix)
3. URI string like `/res/search.xml` or `res/search.xml?domain=...`

So we should check that the first and the senсond conditions are false simultaneously. If the last one statement correct then we should concatenate URL prefix and URI string.
  