### PR TITLE
Replace `file://` URLs with relative URLs

### DIFF
--- a/src/Action/Server.hs
+++ b/src/Action/Server.hs
@@ -126,7 +126,8 @@ replyServer log local haddock store cdn home htmlDir scope Input{..} = case inpu
         return $ OutputFile $ file ++ (if hasTrailingPathSeparator file then "index.html" else "")
     "file":xs | local -> do
         let x = ['/' | not isWindows] ++ intercalate "/" xs
-        return $ OutputFile $ x ++ (if hasTrailingPathSeparator x then "index.html" else "")
+        outputFile <- readFile $ x ++ (if hasTrailingPathSeparator x then "index.html" else "")
+        return $ OutputText $ lstrPack $ replace "file:///" "file/" outputFile
     xs ->
         -- avoid "" and ".." in the URLs, since they could be trying to browse on the server
         return $ OutputFile $ joinPath $ htmlDir : filter (not . all (== '.')) xs


### PR DESCRIPTION
When serving with `--local`, replace `file://` URLs in files that are
served from disk with relative `file/` URLs.

Fix #236 

Haven't been able to test this because of problems with zlib.h not being found even though there's multiple on my system (arch linux).

Decided to open the PR already anyway for feedback. I'm not sure about the performance implications of readFile and the literal string replacement I"m doing currently, a more proper way would be to parse URLs from the file and replace them with `showURL True` applied to them.