### PR TITLE
Fix Changes.txt 2.0.17.1 version number typo

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,6 @@
 Changelog for Hoogle
 
-2.0.17.1, released 2018-01-27
+5.0.17.1, released 2018-01-27
     #238, only identify the database by the first three version components
     #236, in --local mode replace file:// links in Haddock pages
 5.0.17, released 2018-01-17


### PR DESCRIPTION
The most recent entry contained a typo: 2.0.17.1 instead of 5.0.17.1