### PR TITLE
Footer overlap

### DIFF
--- a/html/hoogle.css
+++ b/html/hoogle.css
@@ -9,11 +9,15 @@ html {
 body {
     margin: 0px;
     padding: 0px;
-    padding-bottom: 4em;
     font-family: sans-serif;
     font-size: 13px;
-    position: relative;
-    min-height: 100%;
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+}
+
+#body {
+    flex-grow: 1;
 }
 
 a img {
@@ -36,7 +40,6 @@ a {
 */
 
 #links {
-    position: relative;
     background: none repeat scroll 0 0 #293845;
     border-top: 5px solid #4E6272;
     color: #DDDDDD;
@@ -163,8 +166,6 @@ form {
     color: #666666;
     width: 100%;
     padding: 1.3em 0;
-    position: absolute;
-    bottom: 0;
     text-align: center;
 }
 

--- a/html/hoogle.css
+++ b/html/hoogle.css
@@ -9,6 +9,7 @@ html {
 body {
     margin: 0px;
     padding: 0px;
+    padding-bottom: 4em;
     font-family: sans-serif;
     font-size: 13px;
     position: relative;
@@ -28,10 +29,6 @@ a:hover {
 a {
     color: #C4451D;
     text-decoration: none;
-}
-
-.push {
-    height: 4em;
 }
 
 /********************************************************************

--- a/html/index.html
+++ b/html/index.html
@@ -32,7 +32,6 @@
 </form>
 <div id="body">
 #{body}
-            <div class="push"></div>
         </div>
         <div id="footer">&copy; <a href="http://ndmitchell.com">Neil Mitchell</a> 2004-2018, version #{version}</div>
     </body>


### PR DESCRIPTION
Using a more modern method based on the flex properties to keep the footer sticking to the bottom of the page but not overlap the last result after the results are updated dynamically.

I did some minor testing after applying the same (at least I hope so) changes in a web inspector for hoogle.haskell.org so some more thorough testing is advisable.

Credit goes to @entuland.