### PR TITLE
Fixup deprecation warning about for function.

### DIFF
--- a/src/Action/Server.hs
+++ b/src/Action/Server.hs
@@ -203,7 +203,7 @@ itemCategories xs =
     nubOrd [("package",strUnpack p) | Just (p,_) <- map targetPackage xs]
 
 showFroms :: Bool -> Maybe FilePath -> [Target] -> String
-showFroms local haddock xs = intercalate ", " $ for pkgs $ \p ->
+showFroms local haddock xs = intercalate ", " $ (flip map) pkgs $ \p ->
     let ms = filter ((==) p . targetPackage) xs
     in unwords ["<a href=\"" ++ showURL local haddock b ++ "\">" ++ strUnpack a ++ "</a>" | (a,b) <- catMaybes $ p : map remod ms]
     where


### PR DESCRIPTION
    src/Action/Server.hs:206:49: warning: [-Wdeprecations]
    In the use of for (imported from Data.List.Extra):
    Deprecated: Use flip map directly, since this function clashes with Data.Traversable.for

Thanks for the pull request!

By raising this pull request you confirm you are licensing your contribution under all licenses that apply to this project (see LICENSE) and that you have no patents covering your contribution.

If you care, my PR preferences are at https://github.com/ndmitchell/neil#contributions, but they're all guidelines, and I'm not too fussy - you don't have to read them.
