### PR TITLE
Type search

### DIFF
--- a/.stylish-haskell.yaml
+++ b/.stylish-haskell.yaml
@@ -1,0 +1,241 @@
+# stylish-haskell configuration file
+# ==================================
+
+# The stylish-haskell tool is mainly configured by specifying steps. These steps
+# are a list, so they have an order, and one specific step may appear more than
+# once (if needed). Each file is processed by these steps in the given order.
+steps:
+  # Convert some ASCII sequences to their Unicode equivalents. This is disabled
+  # by default.
+  # - unicode_syntax:
+  #     # In order to make this work, we also need to insert the UnicodeSyntax
+  #     # language pragma. If this flag is set to true, we insert it when it's
+  #     # not already present. You may want to disable it if you configure
+  #     # language extensions using some other method than pragmas. Default:
+  #     # true.
+  #     add_language_pragma: true
+
+  # Align the right hand side of some elements.  This is quite conservative
+  # and only applies to statements where each element occupies a single
+  # line.
+  - simple_align:
+      cases: true
+      top_level_patterns: false
+      records: false
+
+  # Import cleanup
+  - imports:
+      # There are different ways we can align names and lists.
+      #
+      # - global: Align the import names and import list throughout the entire
+      #   file.
+      #
+      # - file: Like global, but don't add padding when there are no qualified
+      #   imports in the file.
+      #
+      # - group: Only align the imports per group (a group is formed by adjacent
+      #   import lines).
+      #
+      # - none: Do not perform any alignment.
+      #
+      # Default: global.
+      align: global
+
+      # The following options affect only import list alignment.
+      #
+      # List align has following options:
+      #
+      # - after_alias: Import list is aligned with end of import including
+      #   'as' and 'hiding' keywords.
+      #
+      #   > import qualified Data.List      as List (concat, foldl, foldr, head,
+      #   >                                          init, last, length)
+      #
+      # - with_alias: Import list is aligned with start of alias or hiding.
+      #
+      #   > import qualified Data.List      as List (concat, foldl, foldr, head,
+      #   >                                 init, last, length)
+      #
+      # - with_module_name: Import list is aligned `list_padding` spaces after
+      #   the module name.
+      #
+      #   > import qualified Data.List      as List (concat, foldl, foldr, head,
+      #                          init, last, length)
+      #
+      #   This is mainly intended for use with `pad_module_names: false`.
+      #
+      #   > import qualified Data.List as List (concat, foldl, foldr, head,
+      #                          init, last, length, scanl, scanr, take, drop,
+      #                          sort, nub)
+      #
+      # - new_line: Import list starts always on new line.
+      #
+      #   > import qualified Data.List      as List
+      #   >     (concat, foldl, foldr, head, init, last, length)
+      #
+      # Default: after_alias
+      list_align: after_alias
+
+      # Right-pad the module names to align imports in a group:
+      #
+      # - true: a little more readable
+      #
+      #   > import qualified Data.List       as List (concat, foldl, foldr,
+      #   >                                           init, last, length)
+      #   > import qualified Data.List.Extra as List (concat, foldl, foldr,
+      #   >                                           init, last, length)
+      #
+      # - false: diff-safe
+      #
+      #   > import qualified Data.List as List (concat, foldl, foldr, init,
+      #   >                                     last, length)
+      #   > import qualified Data.List.Extra as List (concat, foldl, foldr,
+      #   >                                           init, last, length)
+      #
+      # Default: true
+      pad_module_names: true
+
+      # Long list align style takes effect when import is too long. This is
+      # determined by 'columns' setting.
+      #
+      # - inline: This option will put as much specs on same line as possible.
+      #
+      # - new_line: Import list will start on new line.
+      #
+      # - new_line_multiline: Import list will start on new line when it's
+      #   short enough to fit to single line. Otherwise it'll be multiline.
+      #
+      # - multiline: One line per import list entry.
+      #   Type with constructor list acts like single import.
+      #
+      #   > import qualified Data.Map as M
+      #   >     ( empty
+      #   >     , singleton
+      #   >     , ...
+      #   >     , delete
+      #   >     )
+      #
+      # Default: inline
+      long_list_align: inline
+
+      # Align empty list (importing instances)
+      #
+      # Empty list align has following options
+      #
+      # - inherit: inherit list_align setting
+      #
+      # - right_after: () is right after the module name:
+      #
+      #   > import Vector.Instances ()
+      #
+      # Default: inherit
+      empty_list_align: inherit
+
+      # List padding determines indentation of import list on lines after import.
+      # This option affects 'long_list_align'.
+      #
+      # - <integer>: constant value
+      #
+      # - module_name: align under start of module name.
+      #   Useful for 'file' and 'group' align settings.
+      list_padding: 4
+
+      # Separate lists option affects formatting of import list for type
+      # or class. The only difference is single space between type and list
+      # of constructors, selectors and class functions.
+      #
+      # - true: There is single space between Foldable type and list of it's
+      #   functions.
+      #
+      #   > import Data.Foldable (Foldable (fold, foldl, foldMap))
+      #
+      # - false: There is no space between Foldable type and list of it's
+      #   functions.
+      #
+      #   > import Data.Foldable (Foldable(fold, foldl, foldMap))
+      #
+      # Default: true
+      separate_lists: true
+
+      # Space surround option affects formatting of import lists on a single
+      # line. The only difference is single space after the initial
+      # parenthesis and a single space before the terminal parenthesis.
+      #
+      # - true: There is single space associated with the enclosing
+      #   parenthesis.
+      #
+      #   > import Data.Foo ( foo )
+      #
+      # - false: There is no space associated with the enclosing parenthesis
+      #
+      #   > import Data.Foo (foo)
+      #
+      # Default: false
+      space_surround: false
+
+  # Language pragmas
+  - language_pragmas:
+      # We can generate different styles of language pragma lists.
+      #
+      # - vertical: Vertical-spaced language pragmas, one per line.
+      #
+      # - compact: A more compact style.
+      #
+      # - compact_line: Similar to compact, but wrap each line with
+      #   `{-#LANGUAGE #-}'.
+      #
+      # Default: vertical.
+      style: compact
+
+      # Align affects alignment of closing pragma brackets.
+      #
+      # - true: Brackets are aligned in same column.
+      #
+      # - false: Brackets are not aligned together. There is only one space
+      #   between actual import and closing bracket.
+      #
+      # Default: true
+      align: true
+
+      # stylish-haskell can detect redundancy of some language pragmas. If this
+      # is set to true, it will remove those redundant pragmas. Default: true.
+      remove_redundant: true
+
+  # Replace tabs by spaces. This is disabled by default.
+  # - tabs:
+  #     # Number of spaces to use for each tab. Default: 8, as specified by the
+  #     # Haskell report.
+  #     spaces: 8
+
+  # Remove trailing whitespace
+  - trailing_whitespace: {}
+
+  # Squash multiple spaces between the left and right hand sides of some
+  # elements into single spaces. Basically, this undoes the effect of
+  # simple_align but is a bit less conservative.
+  # - squash: {}
+
+# A common setting is the number of columns (parts of) code will be wrapped
+# to. Different steps take this into account. Default: 80.
+columns: 80
+
+# By default, line endings are converted according to the OS. You can override
+# preferred format here.
+#
+# - native: Native newline format. CRLF on Windows, LF on other OSes.
+#
+# - lf: Convert to LF ("\n").
+#
+# - crlf: Convert to CRLF ("\r\n").
+#
+# Default: native.
+newline: native
+
+# Sometimes, language extensions are specified in a cabal file or from the
+# command line instead of using language pragmas in the file. stylish-haskell
+# needs to be aware of these, so it can parse the file correctly.
+#
+# No language extensions are enabled by default.
+# language_extensions:
+  # - TemplateHaskell
+  # - QuasiQuotes

--- a/.stylish-haskell.yaml
+++ b/.stylish-haskell.yaml
@@ -39,7 +39,7 @@ steps:
       # - none: Do not perform any alignment.
       #
       # Default: global.
-      align: global
+      align: none
 
       # The following options affect only import list alignment.
       #

--- a/src/Action/Search.hs
+++ b/src/Action/Search.hs
@@ -1,6 +1,4 @@
-{-# LANGUAGE RecordWildCards     #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TupleSections       #-}
+{-# LANGUAGE RecordWildCards, ScopedTypeVariables, TupleSections #-}
 
 module Action.Search
     (actionSearch, withSearch, search
@@ -9,24 +7,24 @@ module Action.Search
     ,action_search_test
     ) where
 
-import           Control.DeepSeq
-import           Control.Monad.Extra
-import           Data.Functor.Identity
-import           Data.List.Extra
-import           Data.Maybe
-import qualified Data.Set              as Set
-import           System.Directory
+import Control.DeepSeq
+import Control.Monad.Extra
+import Data.Functor.Identity
+import Data.List.Extra
+import Data.Maybe
+import qualified Data.Set as Set
+import System.Directory
 
-import           Action.CmdLine
-import           General.Store
-import           General.Str
-import           General.Util
-import           Input.Item
-import           Output.Items
-import           Output.Names
-import           Output.Tags
-import           Output.Types
-import           Query
+import Action.CmdLine
+import General.Store
+import General.Str
+import General.Util
+import Input.Item
+import Output.Items
+import Output.Names
+import Output.Tags
+import Output.Types
+import Query
 
 -- -- generate all
 -- @tagsoup -- generate tagsoup

--- a/src/Action/Search.hs
+++ b/src/Action/Search.hs
@@ -1,4 +1,6 @@
-{-# LANGUAGE TupleSections, RecordWildCards, ScopedTypeVariables #-}
+{-# LANGUAGE RecordWildCards     #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TupleSections       #-}
 
 module Action.Search
     (actionSearch, withSearch, search
@@ -7,24 +9,24 @@ module Action.Search
     ,action_search_test
     ) where
 
-import Control.Monad.Extra
-import Control.DeepSeq
-import Data.Maybe
-import qualified Data.Set as Set
-import Data.List.Extra
-import Data.Functor.Identity
-import System.Directory
+import           Control.DeepSeq
+import           Control.Monad.Extra
+import           Data.Functor.Identity
+import           Data.List.Extra
+import           Data.Maybe
+import qualified Data.Set              as Set
+import           System.Directory
 
-import Output.Items
-import Output.Tags
-import Output.Names
-import Output.Types
-import General.Store
-import Query
-import Input.Item
-import Action.CmdLine
-import General.Util
-import General.Str
+import           Action.CmdLine
+import           General.Store
+import           General.Str
+import           General.Util
+import           Input.Item
+import           Output.Items
+import           Output.Names
+import           Output.Tags
+import           Output.Types
+import           Query
 
 -- -- generate all
 -- @tagsoup -- generate tagsoup

--- a/src/Action/Search.hs
+++ b/src/Action/Search.hs
@@ -53,7 +53,7 @@ actionSearch Search{..} = replicateM_ repeat_ $ -- deliberately reopen the datab
             let parseType x = case parseQuery x of
                                   [QueryType t] -> (pretty t, hseToSig t)
                                   _ -> error $ "Expected a type signature, got: " ++ x
-            putStr $ unlines $ searchTypesDebug store (parseType $ unwords query) (map parseType compare_)
+            putStr $ unlines $ searchFingerprintsDebug store (parseType $ unwords query) (map parseType compare_)
 
 -- | Returns the details printed out when hoogle --info is called
 targetInfo :: Target -> String

--- a/src/General/Store.hs
+++ b/src/General/Store.hs
@@ -9,32 +9,32 @@ module General.Store(
     Jagged, jaggedFromList, jaggedAsk,
     ) where
 
-import           Control.Applicative
-import           Control.DeepSeq
-import           Control.Exception
-import           Control.Monad.Extra
-import           Data.Binary
-import qualified Data.ByteString.Char8  as BS
-import qualified Data.ByteString.Lazy   as LBS
+import Control.Applicative
+import Control.DeepSeq
+import Control.Exception
+import Control.Monad.Extra
+import Data.Binary
+import qualified Data.ByteString.Char8 as BS
+import qualified Data.ByteString.Lazy as LBS
 import qualified Data.ByteString.Unsafe as BS
-import           Data.Char
-import           Data.IORef.Extra
-import           Data.List.Extra
-import qualified Data.Map               as Map
-import           Data.Typeable
-import qualified Data.Vector.Storable   as V
-import           Data.Version
-import           Foreign.C.String
-import           Foreign.ForeignPtr
-import           Foreign.Ptr
-import           Foreign.Storable
-import           General.Util
-import           Numeric.Extra
-import           Paths_hoogle
-import           Prelude
-import           System.IO.Extra
-import           System.IO.MMap
-import           System.IO.Unsafe
+import Data.Char
+import Data.IORef.Extra
+import Data.List.Extra
+import qualified Data.Map as Map
+import Data.Typeable
+import qualified Data.Vector.Storable as V
+import Data.Version
+import Foreign.C.String
+import Foreign.ForeignPtr
+import Foreign.Ptr
+import Foreign.Storable
+import General.Util
+import Numeric.Extra
+import Paths_hoogle
+import Prelude
+import System.IO.Extra
+import System.IO.MMap
+import System.IO.Unsafe
 
 -- Ensure the string is always 25 chars long, so version numbers don't change its size
 -- Only use the first two components of the version number to identify the database

--- a/src/General/Store.hs
+++ b/src/General/Store.hs
@@ -1,9 +1,5 @@
-{-# LANGUAGE DeriveDataTypeable  #-}
-{-# LANGUAGE GADTs               #-}
-{-# LANGUAGE PatternGuards       #-}
-{-# LANGUAGE RecordWildCards     #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE ViewPatterns        #-}
+{-# LANGUAGE DeriveDataTypeable, GADTs, PatternGuards, RecordWildCards,
+             ScopedTypeVariables, ViewPatterns #-}
 
 module General.Store(
     Typeable, Stored,
@@ -68,9 +64,9 @@ decodeBS = decode . LBS.fromStrict
 
 -- each atom name is either unique (a scope) or "" (a list entry)
 data Atom = Atom
-    {atomType     :: String -- Type that the atom contains (for sanity checking)
+    {atomType :: String -- Type that the atom contains (for sanity checking)
     ,atomPosition :: {-# UNPACK #-} !Int -- Position at which the atom starts in the file
-    ,atomSize     :: {-# UNPACK #-} !Int -- Number of bytes the value takes up
+    ,atomSize :: {-# UNPACK #-} !Int -- Number of bytes the value takes up
     } deriving Show
 
 instance Binary Atom where
@@ -100,9 +96,9 @@ instance forall a . (Typeable a, Storable a) => Stored (V.Vector a) where
 -- WRITE OUT
 
 data SW = SW
-    {swHandle   :: Handle -- Immutable handle I write to
+    {swHandle :: Handle -- Immutable handle I write to
     ,swPosition :: !Int -- Position within swHandle
-    ,swAtoms    :: [(String, Atom)] -- List of pieces, in reverse
+    ,swAtoms :: [(String, Atom)] -- List of pieces, in reverse
     }
 
 newtype StoreWrite = StoreWrite (IORef SW)
@@ -163,9 +159,9 @@ storeWriteAtom (StoreWrite ref) (show . typeOf -> key) part (ptr, len) = do
 -- READ OUT
 
 data StoreRead = StoreRead
-    {srFile  :: FilePath
-    ,srLen   :: Int
-    ,srPtr   :: Ptr ()
+    {srFile :: FilePath
+    ,srLen :: Int
+    ,srPtr :: Ptr ()
     ,srAtoms :: Map.Map String Atom
     }
 

--- a/src/Output/Types.hs
+++ b/src/Output/Types.hs
@@ -379,10 +379,10 @@ readSignatures store = go splitters bs
 
 searchTypeMatch :: StoreRead -> Names -> Int -> Sig Name -> [Int]
 searchTypeMatch store names n sig =
-    map snd $ takeSortOn fst n $
+    map snd $ takeSortOn fst n
       [ (500 * v + fv, i) | (fv, (i, s, f)) <- bestByFingerprint
                           , v  <- maybeToList (test s f)]
-    where bestByFingerprint = takeSortOn fst (max 5000 n) $
+    where bestByFingerprint = takeSortOn fst (max 5000 n)
             [ (fv, (i, s, f)) | (i, s, f) <- zip3 [0..] sigs fs
                              , fv <- maybeToList (matchFingerprint sig f) ]
           sigs = readSignatures store
@@ -471,8 +471,8 @@ foldTy phi = phi . fmap (foldTy phi) . unroll
 prettyTyp :: Show n => Typ n -> String
 prettyTyp = \case
     TyFun typs res -> "<" ++ intercalate ", " (map prettyTyp typs) ++ "; " ++ prettyTyp res ++ ">"
-    TyCon n args -> intercalate " " (show n : map prettyTyp args)
-    TyVar n args -> intercalate " " (show n : map prettyTyp args)
+    TyCon n args -> unwords (show n : map prettyTyp args)
+    TyVar n args -> unwords (show n : map prettyTyp args)
 
 -- Convert a Sig to a Typ.
 toTyp :: Name -> Sig Name -> Typ Name
@@ -588,25 +588,25 @@ unifyTyp lhs rhs = case (lhs, rhs) of
             ok <- unifyName n n'
             if not ok
               then return False
-              else and <$> mapM (uncurry unifyTyp) (zip tys tys')
+              else and <$> zipWithM unifyTyp tys tys'
 
     (TyCon n tys, TyCon n' tys') | length tys == length tys' -> do
             ok <- unifyName n n'
             if not ok
               then return False
-              else and <$> mapM (uncurry unifyTyp) (zip tys tys')
+              else and <$> zipWithM unifyTyp tys tys'
 
     (TyVar n tys, TyVar n' tys') | length tys == length tys' -> do
             ok <- unifyName n n'
             if not ok
               then return False
-              else and <$> mapM (uncurry unifyTyp) (zip tys tys')
+              else and <$> zipWithM unifyTyp tys tys'
 
     (TyFun args ret, TyFun args' ret') | length args == length args' -> do
             ok <- unifyTyp ret ret'
             if not ok
               then return False
-              else and <$> mapM (\(x,y) -> unifyTyp x y) (zip args args')
+              else and <$> zipWithM unifyTyp args args'
 
     _ -> return False
 

--- a/src/Output/Types.hs
+++ b/src/Output/Types.hs
@@ -1,13 +1,6 @@
-{-# LANGUAGE BangPatterns               #-}
-{-# LANGUAGE DeriveDataTypeable         #-}
-{-# LANGUAGE DeriveFunctor              #-}
-{-# LANGUAGE GADTs                      #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE LambdaCase                 #-}
-{-# LANGUAGE RecordWildCards            #-}
-{-# LANGUAGE ScopedTypeVariables        #-}
-{-# LANGUAGE TupleSections              #-}
-{-# LANGUAGE ViewPatterns               #-}
+{-# LANGUAGE BangPatterns, DeriveDataTypeable, DeriveFunctor, GADTs,
+             GeneralizedNewtypeDeriving, LambdaCase, RecordWildCards,
+             ScopedTypeVariables, TupleSections, ViewPatterns #-}
 
 module Output.Types(writeTypes, searchTypes, searchFingerprintsDebug) where
 
@@ -114,7 +107,7 @@ searchFingerprintsDebug store query answers = intercalate [""] $
                 fp = toFingerprint sn
 
                 showExplain = intercalate ", " . map g . sortOn (either (const minBound) (negate . snd))
-                g (Left s)       = "X " ++ s
+                g (Left s) = "X " ++ s
                 g (Right (s, x)) = show x ++ " " ++ s
 
 
@@ -276,7 +269,7 @@ writeFingerprints :: StoreWrite -> [Sig Name] -> IO ()
 writeFingerprints store xs = storeWrite store TypesFingerprints $ V.fromList $ map toFingerprint xs
 
 data MatchFingerprint a ma = MatchFingerprint
-    {mfpAdd  :: a -> a -> a
+    {mfpAdd :: a -> a -> a
     ,mfpAddM :: ma -> ma -> ma
     ,mfpJust :: a -> ma
     ,mfpCost :: String -> Int -> a

--- a/src/Output/Types.hs
+++ b/src/Output/Types.hs
@@ -11,34 +11,34 @@ A quick search finds the most promising 100 fingerprints
 A slow search ranks the 100 items, excluding some
 -}
 
-import           Control.Applicative
-import           Control.Monad.Extra
-import           Control.Monad.ST
-import           Control.Monad.Trans.Class
-import           Control.Monad.Trans.State.Strict
-import           Data.Binary                      hiding (get, put)
-import qualified Data.ByteString.Char8            as BS
-import           Data.Data
-import           Data.Generics.Uniplate.Data
-import           Data.List.Extra
-import qualified Data.Map.Strict                  as Map
-import           Data.Maybe
-import qualified Data.Set                         as Set
-import           Data.STRef
-import           Data.Tuple.Extra
-import qualified Data.Vector.Storable             as V
-import qualified Data.Vector.Storable.Mutable     as VM
-import           Foreign.Storable
-import           Numeric.Extra
-import           Prelude
-import           System.FilePath
-import           System.IO.Extra
+import Control.Applicative
+import Control.Monad.Extra
+import Control.Monad.ST
+import Control.Monad.Trans.Class
+import Control.Monad.Trans.State.Strict
+import Data.Binary hiding (get, put)
+import qualified Data.ByteString.Char8 as BS
+import Data.Data
+import Data.Generics.Uniplate.Data
+import Data.List.Extra
+import qualified Data.Map.Strict as Map
+import Data.Maybe
+import qualified Data.Set as Set
+import Data.STRef
+import Data.Tuple.Extra
+import qualified Data.Vector.Storable as V
+import qualified Data.Vector.Storable.Mutable as VM
+import Foreign.Storable
+import Numeric.Extra
+import Prelude
+import System.FilePath
+import System.IO.Extra
 
-import           General.IString
-import           General.Store
-import           General.Str
-import           General.Util
-import           Input.Item
+import General.IString
+import General.Store
+import General.Str
+import General.Util
+import Input.Item
 
 
 writeTypes :: StoreWrite -> Maybe FilePath -> [(Maybe TargetId, Item)] -> IO ()

--- a/todo3.txt
+++ b/todo3.txt
@@ -1,0 +1,99 @@
+Todo list re: concrete test cases
+
+[ ] Make this todo list into a test suite.
+
+[-] "(a -> [a]) -> [a] -> [a]"
+    [-] should find `concatMap`
+        [X] should find `concatMap` first
+	[ ] should find `concatMap` *from base* first
+    [X] should give `(=<<)` next
+    [X] should give `(>>=)` later on?
+
+[X] "[a] -> Maybe a"
+    [X] should find `listToMaybe` first
+    [X] should find `headMay` in top 10
+
+[-] "a -> [a]"
+    [X] should find `repeat` in top 10
+    [X] should find `singleton` in top 10
+    [-] should find `return` and `pure`
+        [ ] ...in top 10
+    [ ] should have lower search rank for QuickCheck, HaXml hits
+    [X] should *not* match `head`, `last`
+    
+[X] "[a] -> a"
+    [X] should find `head` in top 5
+    [X] should find `last` in top 5
+    [X] should *not* match `repeat`
+
+[X] "[Char] -> Char"
+    [X] should match `head`, `last`
+    [X] should *not* match `mconcat` in top 20
+
+[-] "a -> b"
+    [X] should *not* match `id`
+    [X] should find `unsafeCoerce`
+    [-] should find `coerce`
+        [ ] ...in top 5
+
+[ ] "String -> (Char -> Maybe Char) -> Maybe String" (c/o @ndrssmn)
+    [ ] should match `traverse`
+    [ ] should match `forM`
+    [ ] should match `mapM`
+
+[X] "a -> [(a,b)] -> b" (ndmitchell's favorite example)
+    [X] should not match `zip`
+    [X] should match "lookup :: Eq a => a -> [(a,b)] -> Maybe a"
+    [X] should match `pairsToFunction`
+
+[-] "[(a,b)] -> a -> b" (ndmitchell's favorite example, revisited)
+    [X] should not match `zip`
+    [X] should match "lookup :: Eq a => a -> [(a,b)] -> Maybe a"
+    [X] should match `pairsToFunction`
+
+[ ] "(a -> b -> c) -> (a -> b) -> a -> a"
+    [ ] should match `ap`
+    [ ] should match `(<*>)`
+
+[-] "(a -> m b) -> t a -> m (t b)" (GitHub issue #218)
+    [X] should find `traverse`
+    [X] should find `mapM`
+    [X] should find `forM`
+    [-] should find `mapConcurrently`
+        [ ] ...but rank it after `traverse` and `mapM`
+
+[X] "m (m a) -> m a" (GitHub issue #252)
+    [X] should find `join` as top hit
+
+[X] "String -> Int" (GitHub issue #242)
+    [X] should not find `cursorUpCode :: Int -> String`
+
+[X] "(a -> b) -> f a -> f b" (GitHub issue #213)
+    [X] should find `fmap` as top hit
+    [X] should find `(<$>)`
+    [X] should find `(<&>)`
+    
+[-] GitHub issue #180
+    [X] "a -> b" should not give `id`
+    [-] "IO a -> m a"
+        [X] should find `liftIO`
+	[ ] ...as top hit
+    [-] "a -> m a"
+        [X] should find `pure` and `return`
+	[ ] ...as top hit
+    [X] "(a -> a) -> k -> Map k a -> Map k a" should give `adjust`.
+
+[-] GitHub issue #127
+    [-] "Int -> Integer"
+        [X] should match `toInteger`
+	[X] ...in top 10
+	[ ] ...as top hit.
+    [-] "Integer -> Int"
+        [X] should match `fromInteger`
+	[X] ...in top 10
+	[ ] ...as top hit
+
+[X] "[Parser a] -> Parser a" (GitHub issue #90)
+    [X] should find `choice`
+      
+    


### PR DESCRIPTION
This is a first go at adding type search on top of the fingerprint filtering. The query (or some simple variations of it) is checked against the proposed answer signature by attempting to unify the answer with the query, keeping type variables in the query fixed. The amount of "unification work" needed gives a cost, that is later combined with the fingerprint cost and a heuristic about the number of abstract constraints.

I made a list of test cases (see `todo3.txt`) that did not previously work, to help mark progress as type search is added. Some of the test cases come from github issues, others are things I came across on stackoverflow, twitter, etc. Even this simple type search seems to improve the results quite a bit, compared to fingerprint-only search.

My editor setup made some formatting changes via `stylish-haskell`, adding a bit of noise to this PR. Please do let me know if you'd rather I undid those changes.