### PR TITLE
Scary banner no longer needed

### DIFF
--- a/html/welcome.html
+++ b/html/welcome.html
@@ -6,9 +6,6 @@
 <li><a href="https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/">GHC Manual</a></li>
 <li><a href="https://downloads.haskell.org/~ghc/latest/docs/html/libraries/">Libraries</a></li>
 </ul>
-<p style="border:2px solid red; font-weight: bold; background-color: yellow; padding: 10px; text-align: center;">
-    Warning: <a href="http://neilmitchell.blogspot.co.uk/2015/01/hoogle-5-is-coming.html">Alpha version, type search doesn't work</a>!
-</p>
 <p>
     Hoogle is a Haskell API search engine, which allows you to search the Haskell libraries
     on Stackage by either function name, or by approximate type signature.


### PR DESCRIPTION
Hoogle 5 does seem to support type search now. I haven't checked whether support is as complete as it was 5 years ago, but even if not, I don't think we need this banner anymore.