### PR TITLE
remove reflected-xss CSP entry

### DIFF
--- a/src/General/Web.hs
+++ b/src/General/Web.hs
@@ -113,11 +113,7 @@ server log Server{..} act = do
               <> " upgrade-insecure-requests;"
               -- Do not display http content if the page was loaded under
               -- https.
-              <> " block-all-mixed-content;"
-              -- If the browser manages to detect any reflected XSS attack
-              -- going on, block the page. This is the preferred replacement
-              -- for the X-XSS-Protection header specified below.
-              <> " reflected-xss block"),
+              <> " block-all-mixed-content"),
 
              -- Tells the browser this web page should not be rendered inside a
              -- frame, except if the framing page comes from the same origin


### PR DESCRIPTION
Turns out the CSP entry has been deprecated in favour of the header,
even though the header was there before.

Having the CSP entry does not actively harm anything as far as I can see, but it _is_ redundant and will produce a warning as an unrecognized entry in some browsers.

It looks like the documentation I followed to create the orginal CSP was outdated in that regard.