### PR TITLE
Fix traversal bug

### DIFF
--- a/.ghci
+++ b/.ghci
@@ -1,6 +1,6 @@
 :set -fwarn-unused-binds -fwarn-unused-imports -fwarn-orphans
 :set -isrc
-:load Main src\Paths.hs
+:load Main src/Paths.hs
 
 :def test \xs -> return $ ":main test " ++ xs
 

--- a/src/Action/Server.hs
+++ b/src/Action/Server.hs
@@ -49,7 +49,6 @@ import Prelude
 
 import qualified Data.Aeson as JSON
 
-
 actionServer :: CmdLine -> IO ()
 actionServer cmd@Server{..} = do
     -- so I can get good error messages
@@ -72,7 +71,7 @@ actionServer cmd@Server{..} = do
 actionReplay :: CmdLine -> IO ()
 actionReplay Replay{..} = withBuffering stdout NoBuffering $ do
     src <- readFile logs
-    let qs = [readInput url | _:ip:_:url:_ <- map words $ lines src, ip /= "-"]
+    let qs = catMaybes [readInput url | _:ip:_:url:_ <- map words $ lines src, ip /= "-"]
     (t,_) <- duration $ withSearch database $ \store -> do
         log <- logNone
         dataDir <- getDataDir

--- a/src/General/Web.hs
+++ b/src/General/Web.hs
@@ -12,9 +12,9 @@ import Action.CmdLine
 import Network.Wai.Logger
 import Network.Wai
 import Control.DeepSeq
+import Network.HTTP.Types (parseQuery, decodePathSegments)
 import Network.HTTP.Types.Status
 import qualified Data.Text as Text
-import General.Str
 import qualified Data.ByteString.Char8 as BS
 import qualified Data.ByteString.Lazy.Char8 as LBS
 import Data.List.Extra
@@ -36,14 +36,21 @@ data Input = Input
     ,inputArgs :: [(String, String)]
     } deriving Show
 
-readInput :: String -> Input
-readInput (breakOn "?" -> (a,b)) = Input (filter (not . badPath) $ dropWhile null $ splitOn "/" a) $
-    filter (not . badArg . fst) $ map (second (unEscapeString . drop1) . breakOn "=") $ splitOn "&" $ drop1 b
-    where
-        -- avoid "" and ".." in the URLs, since they could be trying to browse on the server
-        badPath xs = xs == "" || all (== '.') xs
-
-        badArg xs = xs == "" || any (not . isLower) xs
+readInput :: String -> Maybe Input
+readInput (breakOn "?" -> (a,b)) =
+  if (badPath path || badArgs args) then Nothing else Just $ Input path args
+  where
+    path = parsePath a
+    parsePath = map Text.unpack
+              . decodePathSegments
+              . BS.pack
+    badPath = any $ all (== '.')
+    args = parseArgs b
+    parseArgs = map (\(n, v) -> (BS.unpack n, maybe "" BS.unpack v))
+              . parseQuery
+              . BS.pack
+    badArgs = any (any (not . isLower))
+            . map fst
 
 data Output
     = OutputText LBS.ByteString


### PR DESCRIPTION
There is a bug in the current path handling code that allows an attacker with direct access to the hoogle server to force it to return files it has access to. This does *not* seem to work through an nginx proxy such as the setup on hoogle.haskell.org.

Repro on current master:

```                                                                                                                                                                                    
$ git clone git@github.com:ndmitchell/hoogle.git
Cloning into 'hoogle'...
[...]
$ cd hoogle
$ git rev-parse HEAD
4fc77219521055ac96eca9908b4fb9a63ec9a0c5
$ stack init
[...]
* Matches nightly-2019-05-27

Selected resolver: nightly-2019-05-27
Initialising configuration using resolver: nightly-2019-05-27
Total number of user packages considered: 1
Writing configuration to file: stack.yaml
All done.
$ stack build
[...]
$ stack exec -- hoogle generate --local
Starting generate
Reading ghc-pkg... 0.12s
[11/143] attoparsec... 0.06s
[16/143] basement... 0.23s
[35/143] cryptonite... 0.10s
[52/143] ghc... 2.40s
[76/143] memory... 0.02s
[116/143] transformers... 0.08s
[141/143] zlib... 0.03s
Packages missing documentation: hoogle rts
Found 134 warnings when processing items

Reordering items... 0.02s
Writing tags... 0.15s
Writing names... 0.14s
Writing types... 0.89s
Took 10.31s
$ echo hi > hello
$ stack exec -- hoogle server --port=8080 --local > log.txt &
[1] 35053
$ curl localhost:8080/%2e%2e/%2e%2e/%2e%2e/%2e%2e/%2e%2e/%2e%2e/%2e%2e/%2e%2e/%2e%2e/hello
hi
$
```

This PR tries to solve that problem by bridging the existing gap between URI parsing for replays (which does attempt to prevent this kind of issue) and for the server, which for some reason use completely different code paths.