### PR TITLE
Fix overflows of arity and term differences

### DIFF
--- a/src/Output/Types.hs
+++ b/src/Output/Types.hs
@@ -314,7 +314,7 @@ matchFingerprintEx MatchFingerprint{..} sig@(toFingerprint -> target) =
     where
         -- CAFs must match perfectly, otherwise too many is better than too few
         arity | ta == 0 = \ca -> if ca == 0 then mfpJust $ mfpCost "arity equal" 0 else mfpMiss "arity different and query a CAF" -- searching for a CAF
-              | otherwise = \ca -> case fromIntegral $ ca - ta of
+              | otherwise = \ca -> case fromIntegral ca - fromIntegral ta of
                     _ | ca == 0 -> mfpMiss "arity different and answer a CAF" -- searching for a CAF
                     0  -> mfpJust $ mfpCost "arity equal" 0 -- perfect match
                     -1 -> mfpJust $ mfpCost "arity 1 to remove" 1000 -- not using something the user carefully wrote
@@ -327,7 +327,7 @@ matchFingerprintEx MatchFingerprint{..} sig@(toFingerprint -> target) =
                 allowMore = TVar name0 [] `elem` sigTy sig
 
         -- missing terms are a bit worse than invented terms, but it's fairly balanced, clip at large numbers
-        terms = \ct -> case fromIntegral $ ct - tt of
+        terms = \ct -> case fromIntegral ct - fromIntegral tt of
                 n | abs n > 20 -> mfpMiss $ "terms " ++ show n ++ " different" -- too different
                   | n == 0 -> mfpJust $ mfpCost "terms equal" 0
                   | n > 0 -> mfpJust $ mfpCost ("terms " ++ show n ++ " to add") $ n * 10 -- candidate has more terms


### PR DESCRIPTION
When comparing fingerprints, instead of getting differences of negative numbers
like -1 we were getting 255 because of overflowing. This meant we had dead code
for the conditions to give a cost of 1000 for removing an arity and a cost of 12
for removing a term. Now we correctly execute these code paths.

Given the following:

    Query: Bool -> Bool -> Bool
    Sig String: Bool -> Bool -> Bool
    Sig Name: C65532 -> C65532 -> C65532
    Fingerprint: arity=2, terms=3, rarity=C65532 _ _

We used to get:

    Answer 1: Bool -> Bool
    Sig String: Bool -> Bool
    Sig Name: C65532 -> C65532
    Fingerprint: arity=1, terms=2, rarity=C65532 _ _
    Cost: X, no match
    Explain: X , X terms 255 different, 0 term in common C65532, 0 term in
    common _, 0 term in common _, 0 term in common C65532, 0 term in common _, 0
    term in common _

Now we get:

    Answer 1: Bool -> Bool
    Sig String: Bool -> Bool
    Sig Name: C65532 -> C65532
    Fingerprint: arity=1, terms=2, rarity=C65532 _ _
    Cost: 1012
    Explain: 1000 arity 1 to remove, 12 terms 1 to remove, 0 term in common
    C65532, 0 term in common _, 0 term in common _, 0 term in common C65532, 0
    term in common _, 0 term in common _

Thanks for the pull request!

By raising this pull request you confirm you are licensing your contribution under all licenses that apply to this project (see LICENSE) and that you have no patents covering your contribution.

If you care, my PR preferences are at https://github.com/ndmitchell/neil#contributions, but they're all guidelines, and I'm not too fussy - you don't have to read them.
