### PR TITLE
Check if server is local and apply path validations only if not

### DIFF
--- a/src/Action/Server.hs
+++ b/src/Action/Server.hs
@@ -71,7 +71,7 @@ actionServer cmd@Server{..} = do
 actionReplay :: CmdLine -> IO ()
 actionReplay Replay{..} = withBuffering stdout NoBuffering $ do
     src <- readFile logs
-    let qs = catMaybes [readInput url | _:ip:_:url:_ <- map words $ lines src, ip /= "-"]
+    let qs = catMaybes [readInput url False | _:ip:_:url:_ <- map words $ lines src, ip /= "-"]
     (t,_) <- duration $ withSearch database $ \store -> do
         log <- logNone
         dataDir <- getDataDir


### PR DESCRIPTION
Fixes #314 

Not having this check would throw a `Bad URL` error when path contains `.` in
them which could be a local file path too.

One reason I'm not happy with this fix is that, now `readInput` is tied to a `Bool` and logic is applied based on that, which I think it shouldn't.

On the other hand, if I have a separate `validateInput` function which handles the parse and the check, then that's something I'd have to call at both the files that I've changed, which in my opinion is a good change for the better.

If you could guide or suggest if this change is okay, I'd understand, and if not, do let me know how to approach for the fix so that it's clear code wise and I shall make the changes.