### PR TITLE
Fix `Bad URL` error when a package is clicked

### DIFF
--- a/src/General/Web.hs
+++ b/src/General/Web.hs
@@ -44,7 +44,7 @@ readInput (breakOn "?" -> (a,b)) =
     parsePath = map Text.unpack
               . decodePathSegments
               . BS.pack
-    badPath = any $ all (== '.')
+    badPath = any (all (== '.')) . filter (/= "")
     args = parseArgs b
     parseArgs = map (\(n, v) -> (BS.unpack n, maybe "" BS.unpack v))
               . parseQuery


### PR DESCRIPTION
Fixes #314 
This happens only when run with `--local` flag and a package name is clicked as
it doesn't have a specific file path in the URL.

`decodePathSegments` adds an empty string if the path ends with a `/`

And because of this `all (== '.') ""` returns `True` which then makes it a bad
path according to the previous logic.