### PR TITLE
fix escaping in packages list (on the left)

### DIFF
--- a/src/Action/Server.hs
+++ b/src/Action/Server.hs
@@ -205,10 +205,10 @@ showResults local links haddock args query results = do
             "&filter=" ++ intercalate "|" (mapMaybe (fmap fst . targetModule) ts) ++
             "&precise=on"
 
-        add x = ("?" ++) $ intercalate "&amp;" $ map (joinPair "=") $
+        add x = ("?" ++) $ intercalate "&" $ map (joinPair "=") $
             case break ((==) "hoogle" . fst) args of
                 (a,[]) -> a ++ [("hoogle", x)]
-                (a,(_,x1):b) -> a ++ [("hoogle", x1 ++ " " ++ x)] ++ b
+                (a,(_,x1):b) -> a ++ [("hoogle", escapeURL x1 ++ " " ++ x)] ++ b
 
         f cat val = do
             H.a ! H.class_" minus" ! H.href (H.stringValue $ add $ "-" ++ cat ++ ":" ++ val) $ ""


### PR DESCRIPTION
Currently:

1. search for `&&`
2. click on one of the links in the "Packages" list on the left
3. oops: `Bad URL: /?hoogle=&&%20package:base&amp;scope=set:stackage"`

This PR fixes that (and removes double-escaping of `&`).