### PR TITLE
fix unicode search

### DIFF
--- a/src/General/Web.hs
+++ b/src/General/Web.hs
@@ -29,6 +29,7 @@ import Control.Exception.Extra
 import System.Time.Extra
 import General.Log
 import Prelude
+import qualified Data.ByteString.UTF8 as UTF8
 
 
 data Input = Input
@@ -46,9 +47,9 @@ readInput (breakOn "?" -> (a,b)) =
               . BS.pack
     badPath = any (all (== '.')) . filter (/= "")
     args = parseArgs b
-    parseArgs = map (BS.unpack *** maybe "" BS.unpack)
+    parseArgs = map (UTF8.toString *** maybe "" UTF8.toString)
               . parseQuery
-              . BS.pack
+              . UTF8.fromString
     badArgs = any (any (not . isLower))
             . map fst
 


### PR DESCRIPTION
fixes #324

I haven't exhaustively tested whether this breaks anything, but it works locally with:

```
$ cat misc/sample-data/foo-1.0/foo.txt
@url http://eghmitchell.co.uk/
@package foo
@version 1.0

module Foo
@url #a_foo
猫 :: String
x猫 :: String
neko :: String
(≠) :: Eq a => a -> a -> Bool
(/=) :: Eq a => a -> a -> Bool
$ cabal run hoogle -- generate --local=misc/sample-data/foo-1.0/
$ cabal run hoogle -- server -p 8888 --host 127.0.0.1
```

--> http://localhost:8888/?hoogle=≠ works :)

I did find that `猫` is not indexed by `generate`, but that's a bug in `haskell-src-exts`.