### PR TITLE
Add option to get plain text on JSON responses

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -76,4 +76,38 @@ The Hoogle website provides JSON output using the parameter `?mode=json`. As an 
       }
     ]
 
-This output has been reformatted to better fit the screen. Future versions of Hoogle may produce different JSON output.
+Another possible option is to set the `?format` query parameter to `text` (only current possible value), to remove the HTML tags from the `item` and `docs` properties of the output.
+
+    $ curl -sS "https://hoogle.haskell.org?mode=json&format=text&hoogle=map&start=1&count=2"
+    [
+      {
+        "url": "https://hackage.haskell.org/package/base/docs/Prelude.html#v:map",
+        "module": {
+          "url": "https://hackage.haskell.org/package/base/docs/Prelude.html",
+          "name": "Prelude"
+        },
+        "package": {
+          "url": "https://hackage.haskell.org/package/base",
+          "name": "base"
+        },
+        "item": "map :: (a -> b) -> [a] -> [b]",
+        "type": "",
+        "docs": "map f xs is the list obtained by applying f\nto each element of xs, i.e.,\n\n\nmap f [x1, x2, ..., xn] == [f x1, f x2, ..., f xn]\nmap f [x1, x2, ...] == [f x1, f x2, ...]\n\n"
+      },
+      {
+        "url": "https://hackage.haskell.org/package/base/docs/Data-List.html#v:map",
+        "module": {
+          "url": "https://hackage.haskell.org/package/base/docs/Data-List.html",
+          "name": "Data.List"
+        },
+        "package": {
+          "url": "https://hackage.haskell.org/package/base",
+          "name": "base"
+        },
+        "item": "map :: (a -> b) -> [a] -> [b]",
+        "type": "",
+        "docs": "map f xs is the list obtained by applying f\nto each element of xs, i.e.,\n\n\nmap f [x1, x2, ..., xn] == [f x1, f x2, ..., f xn]\nmap f [x1, x2, ...] == [f x1, f x2, ...]\n\n"
+      }
+    ]
+    
+These JSON outputs have been reformatted to better fit the screen. Future versions of Hoogle may produce different JSON output.

--- a/src/Action/Server.hs
+++ b/src/Action/Server.hs
@@ -115,7 +115,11 @@ replyServer log local links haddock store cdn home htmlDir scope Input{..} = cas
                   -- by default it returns 100 entries
                   count :: Int
                   count = min 500 $ grabInt "count" 100
-              in pure $ OutputJSON $ JSON.toEncoding $ take count $ drop start results
+                  filteredResults = take count $ drop start results
+              in case lookup "format" inputArgs of
+                Just "text" -> pure $ OutputJSON $ JSON.toEncoding $ map unHTMLTarget filteredResults
+                _ -> pure $ OutputJSON $ JSON.toEncoding filteredResults
+                
             Just m -> return $ OutputFail $ lbstrPack $ "Mode " ++ m ++ " not (currently) supported"
     ["plugin","jquery.js"] -> OutputFile <$> JQuery.file
     ["plugin","jquery.flot.js"] -> OutputFile <$> Flot.file Flot.Flot

--- a/src/Action/Server.hs
+++ b/src/Action/Server.hs
@@ -118,7 +118,8 @@ replyServer log local links haddock store cdn home htmlDir scope Input{..} = cas
                   filteredResults = take count $ drop start results
               in case lookup "format" inputArgs of
                 Just "text" -> pure $ OutputJSON $ JSON.toEncoding $ map unHTMLTarget filteredResults
-                _ -> pure $ OutputJSON $ JSON.toEncoding filteredResults
+                Just f -> return $ OutputFail $ lbstrPack $ "Format mode " ++ f ++ " not (currently) supported"
+                Nothing -> pure $ OutputJSON $ JSON.toEncoding filteredResults
                 
             Just m -> return $ OutputFail $ lbstrPack $ "Mode " ++ m ++ " not (currently) supported"
     ["plugin","jquery.js"] -> OutputFile <$> JQuery.file

--- a/src/Action/Server.hs
+++ b/src/Action/Server.hs
@@ -120,7 +120,6 @@ replyServer log local links haddock store cdn home htmlDir scope Input{..} = cas
                 Just "text" -> pure $ OutputJSON $ JSON.toEncoding $ map unHTMLTarget filteredResults
                 Just f -> return $ OutputFail $ lbstrPack $ "Format mode " ++ f ++ " not (currently) supported"
                 Nothing -> pure $ OutputJSON $ JSON.toEncoding filteredResults
-                
             Just m -> return $ OutputFail $ lbstrPack $ "Mode " ++ m ++ " not (currently) supported"
     ["plugin","jquery.js"] -> OutputFile <$> JQuery.file
     ["plugin","jquery.flot.js"] -> OutputFile <$> Flot.file Flot.Flot

--- a/src/Input/Item.hs
+++ b/src/Input/Item.hs
@@ -173,7 +173,7 @@ targetExpandURL t@Target{..} = t{targetURL = url, targetModule = second (const m
                  | otherwise = a ++ b
 
 unHTMLTarget :: Target -> Target
-unHTMLTarget t@Target {targetItem=item, targetDocs=docs} = t {targetItem=(unHTML item), targetDocs=(unHTML docs)}
+unHTMLTarget t@Target {..} = t{targetItem=unHTML targetItem, targetDocs=unHTML targetDocs}
 
 splitIPackage, splitIModule :: [(a, Item)] -> [(Str, [(a, Item)])]
 splitIPackage = splitUsing $ \x -> case snd x of IPackage x -> Just x; _ -> Nothing

--- a/src/Input/Item.hs
+++ b/src/Input/Item.hs
@@ -7,7 +7,8 @@ module Input.Item(
     Item(..), itemName,
     Target(..), targetExpandURL, TargetId(..),
     splitIPackage, splitIModule,
-    hseToSig, hseToItem, item_test
+    hseToSig, hseToItem, item_test,
+    unHTMLTarget
     ) where
 
 import Numeric
@@ -171,6 +172,8 @@ targetExpandURL t@Target{..} = t{targetURL = url, targetModule = second (const m
                  | ':':_ <- dropWhile isAsciiLower b = b -- match http: etc
                  | otherwise = a ++ b
 
+unHTMLTarget :: Target -> Target
+unHTMLTarget t@Target {targetItem=item, targetDocs=docs} = t {targetItem=(unHTML item), targetDocs=(unHTML docs)}
 
 splitIPackage, splitIModule :: [(a, Item)] -> [(Str, [(a, Item)])]
 splitIPackage = splitUsing $ \x -> case snd x of IPackage x -> Just x; _ -> Nothing


### PR DESCRIPTION
After discussing in https://github.com/ndmitchell/hoogle/issues/337, I decided to follow the suggestion of having a new query parameter called `format`, that currently supports only the `text` value (which will rip out any HTML code in the results). It only works if the request is made in `json` mode, otherwise it's ignored (I didn't think it was necessary to change it for other modes, but I'm surely open to discussions).

Other than that, maybe adding some tests and instructions to https://github.com/ndmitchell/hoogle/blob/master/docs/API.md would be good.

I'm open to any comments!