### PR TITLE
Have --local flag generate a set with the directory name

### DIFF
--- a/src/Action/Generate.hs
+++ b/src/Action/Generate.hs
@@ -147,7 +147,7 @@ readHaskellDirs timing settings dirs = do
         return (strPack $ takeBaseName fp, pkg)
 
     generateBarePackage (name, dir) =
-        (name, mempty{packageTags = [(strPack "set", strPack "all")] ++ sets})
+        (name, mempty{packageTags = (strPack "set", strPack "all") : sets})
       where
         sets = map setFromDir $ filter (`isPrefixOf` dir) dirs
 

--- a/src/Action/Generate.hs
+++ b/src/Action/Generate.hs
@@ -146,12 +146,11 @@ readHaskellDirs timing settings dirs = do
         let pkg = readCabal settings src
         return (strPack $ takeBaseName fp, pkg)
 
-    generateBarePackage (name, dir) =
+    generateBarePackage (name, file) =
         (name, mempty{packageTags = (strPack "set", strPack "all") : sets})
       where
-        sets = map setFromDir $ filter (`isPrefixOf` dir) dirs
-
-        setFromDir dir = (strPack "set", strPack (takeFileName $ dropTrailingPathSeparator dir))
+        sets = map setFromDir $ filter (`isPrefixOf` file) dirs
+        setFromDir dir = (strPack "set", strPack $ takeFileName $ dropTrailingPathSeparator dir)
 
 readFregeOnline :: Timing -> Download -> IO (Map.Map PkgName Package, Set.Set PkgName, ConduitT () (PkgName, URL, LBStr) IO ())
 readFregeOnline timing download = do

--- a/src/Action/Generate.hs
+++ b/src/Action/Generate.hs
@@ -138,13 +138,20 @@ readHaskellDirs timing settings dirs = do
             yield (name, url, lbstrFromChunks [src])
     return (Map.union
                 (Map.fromList cabals)
-                (Map.fromList $ map ((,mempty{packageTags=[(strPack "set",strPack "all")]}) . fst) packages)
+                (Map.fromList $ map generateBarePackage packages)
            ,Set.fromList $ map fst packages, source)
   where
     parseCabal fp = do
         src <- readFileUTF8' fp
         let pkg = readCabal settings src
         return (strPack $ takeBaseName fp, pkg)
+
+    generateBarePackage (name, dir) =
+        (name, mempty{packageTags = [(strPack "set", strPack "all")] ++ sets})
+      where
+        sets = map setFromDir $ filter (`isPrefixOf` dir) dirs
+
+        setFromDir dir = (strPack "set", strPack (takeFileName $ dropTrailingPathSeparator dir))
 
 readFregeOnline :: Timing -> Download -> IO (Map.Map PkgName Package, Set.Set PkgName, ConduitT () (PkgName, URL, LBStr) IO ())
 readFregeOnline timing download = do

--- a/src/Action/Search.hs
+++ b/src/Action/Search.hs
@@ -130,7 +130,7 @@ action_search_test sample database = testing "Action.Search.search" $ withSearch
         "__suffix__" === "http://henry.com?too_long"
         "__infix__" === "http://henry.com?too_long"
         "Wife" === "http://eghmitchell.com/Mitchell.html#a_wife"
-        completionTags store `testEq` ["set:all","package:emily","package:henry"]
+        completionTags store `testEq` ["set:all","set:sample-data","package:emily","package:henry"]
      else do
         "base" === hackage "base"
         "Prelude" === hackage "base/docs/Prelude.html"


### PR DESCRIPTION
This will take the name of the directory that the `--local` flag is passed and create a set named after it.

This doesn't handle all the cases I would like it to\*, but it's a good basic start and more complex functionality can be built on it in the future.

Addresses the basic case of #341 .

---

\* The biggest thing being having the same package in multiple sets, which isn't handled at all and results in the "higher priority" package in the [sort that's used to get the highest version package](https://github.com/ndmitchell/hoogle/blob/master/src/Action/Generate.hs#L127-L131) being the thing that determines the set it's in.