### PR TITLE
Improve `--local` set functionality

### DIFF
--- a/src/Action/Generate.hs
+++ b/src/Action/Generate.hs
@@ -138,7 +138,7 @@ readHaskellDirs timing settings dirs = do
             yield (name, url, lbstrFromChunks [src])
     return (Map.union
                 (Map.fromList cabals)
-                (Map.fromList $ map generateBarePackage packages)
+                (Map.fromListWith (<>) $ map generateBarePackage packages)
            ,Set.fromList $ map fst packages, source)
   where
     parseCabal fp = do


### PR DESCRIPTION
This improves the functionality introduced #342 and constitutes more progress on #341 .

Now packages can be in multiple sets.

Basically, since you're generating a bare package for .txt file documentation found, it's fine to just mappend them. If you did this with cabal generated ones it would be a mishmash, but we're not!