### PR TITLE
Add flag to disable network tests.

### DIFF
--- a/src/Action/CmdLine.hs
+++ b/src/Action/CmdLine.hs
@@ -70,9 +70,10 @@ data CmdLine
         ,scope :: String
         }
     | Test
-        {deep :: Bool
-        ,database :: FilePath
-        ,language :: Language
+        { deep :: Bool
+        , disable_network_tests  :: Bool
+        , database :: FilePath
+        , language :: Language
         }
       deriving (Data,Typeable,Show)
 
@@ -153,5 +154,6 @@ replay = Replay
     } &= help "Replay a log file"
 
 test = Test
-    {deep = False &= help "Run extra long tests"
+    { deep    = False &= help "Run extra long tests"
+    , disable_network_tests = False  &= help "Disables the use of network tests"
     } &= help "Run the test suite"

--- a/src/Action/Test.hs
+++ b/src/Action/Test.hs
@@ -31,15 +31,16 @@ actionTest Test{..} = withBuffering stdout NoBuffering $ withTempFile $ \sample 
     putStrLn "Sample database tests"
     actionGenerate defaultGenerate{database=sample, local_=["misc/sample-data"]}
     action_search_test True sample
-    action_server_test True sample
+    unless disable_network_tests $ action_server_test True sample
     putStrLn ""
 
-    putStrLn "Haskell.org database tests"
-    action_search_test False database
-    action_server_test False database
+    unless disable_network_tests $ do
+        putStrLn "Haskell.org database tests"
+        action_search_test False database
+        action_server_test False database
 
-    when deep $ withSearch database $ \store -> do
-        putStrLn "Deep tests"
-        let xs = map targetItem $ listItems store
-        evaluate $ rnf xs
-        putStrLn $ "Loaded " ++ show (length xs) ++ " items"
+        when deep $ withSearch database $ \store -> do
+            putStrLn "Deep tests"
+            let xs = map targetItem $ listItems store
+            evaluate $ rnf xs
+            putStrLn $ "Loaded " ++ show (length xs) ++ " items"


### PR DESCRIPTION
The without this, it is impossible to run tests in a sandbox environment such as that used by gentoo's portage package manager.

Signed-off-by: Wolfgang E. Sanyer <WolfgangESanyer@gmail.com>

Thanks for the pull request!

By raising this pull request you confirm you are licensing your contribution under all licenses that apply to this project (see LICENSE) and that you have no patents covering your contribution.

If you care, my PR preferences are at https://github.com/ndmitchell/neil#contributions, but they're all guidelines, and I'm not too fussy - you don't have to read them.
