### PR TITLE
Fix URL validation logic

### DIFF
--- a/src/Action/Test.hs
+++ b/src/Action/Test.hs
@@ -8,6 +8,7 @@ import Action.Search
 import Action.Server
 import Action.Generate
 import General.Util
+import General.Web
 import Input.Item
 import Input.Haddock
 import System.IO.Extra
@@ -22,6 +23,7 @@ actionTest :: CmdLine -> IO ()
 actionTest Test{..} = withBuffering stdout NoBuffering $ withTempFile $ \sample -> do
     putStrLn "Code tests"
     general_util_test
+    general_web_test
     input_haddock_test
     query_test
     action_server_test_


### PR DESCRIPTION
This fixes another directory traversal for paths of the form
http://localhost:8080/..%2f..%2f..%2f..%2f..%2f..%2f..%2f..%2f..%2f..%2f..%2f..%2f..%2f..%2f..%2f..%2fetc/nixos/configuration.nix.

Also added a bunch of tests for the validation logic since I really
don’t trust it given that this is the second issue after the first one
got fixed almost two years ago in #306.

I’m also starting to wonder if hoogle should have an option to just
disable the generic file server completely. In anything some type of
production setup, serving the required static assets via nginx seems
like a much more sensible solution than trying to get this right in
hoogle.

Thanks for the pull request!

By raising this pull request you confirm you are licensing your contribution under all licenses that apply to this project (see LICENSE) and that you have no patents covering your contribution.

If you care, my PR preferences are at https://github.com/ndmitchell/neil#contributions, but they're all guidelines, and I'm not too fussy - you don't have to read them.
