### PR TITLE
Serve static files via wai-app-static

### DIFF
--- a/hoogle.cabal
+++ b/hoogle.cabal
@@ -79,6 +79,7 @@ library
         utf8-string,
         vector,
         wai,
+        wai-app-static,
         wai-logger,
         warp,
         warp-tls,

--- a/src/Action/Server.hs
+++ b/src/Action/Server.hs
@@ -62,9 +62,10 @@ actionServer cmd@Server{..} = do
     putStrLn . showDuration =<< time
     evaluate spawned
     dataDir <- maybe getDataDir pure datadir
+    let htmlDir = dataDir </> "html"
     haddock <- maybe (pure Nothing) (fmap Just . canonicalizePath) haddock
     withSearch database $ \store ->
-        server log cmd $ replyServer log local links haddock store cdn home (dataDir </> "html") scope
+        server log cmd htmlDir $ replyServer log local links haddock store cdn home htmlDir scope
 
 actionReplay :: CmdLine -> IO ()
 actionReplay Replay{..} = withBuffering stdout NoBuffering $ do
@@ -157,8 +158,7 @@ replyServer log local links haddock store cdn home htmlDir scope Input{..} = cas
             -- Haddock incorrectly generates file:// on Windows, when it should be file:///
             -- so replace on file:// and drop all leading empty paths above
             pure $ OutputHTML $ lbstrPack $ replace "file://" "/file/" src
-    xs ->
-        pure $ OutputFile $ joinPath $ htmlDir : xs
+    xs -> pure OutputStaticFile
     where
         html = templateMarkup
         text = templateMarkup . H.string


### PR DESCRIPTION
After pondering #367 for a while, this seemed like a nicer solution
than providing an option to disable this:

wai-app-static is pretty battletested at this point, it’s well
maintained, has relatively few dependencies and it provides some extra
functionality around caching which may be useful.

That way, we avoid our own validation logic which was broken several
times and I’m not surprised if it’s broken again.

This PR does not address haddock: and file: links. Those deliberately
do not limit paths but they are also disabled by default so from a
security pov this is less of an issue.

Thanks for the pull request!

By raising this pull request you confirm you are licensing your contribution under all licenses that apply to this project (see LICENSE) and that you have no patents covering your contribution.

If you care, my PR preferences are at https://github.com/ndmitchell/neil#contributions, but they're all guidelines, and I'm not too fussy - you don't have to read them.
