### PR TITLE
Allow for JSONL output for search command

### DIFF
--- a/src/Action/CmdLine.hs
+++ b/src/Action/CmdLine.hs
@@ -8,14 +8,14 @@ module Action.CmdLine(
     whenLoud, whenNormal
     ) where
 
+import Data.List.Extra
+import Data.Version
+import General.Util
+import Paths_hoogle (version)
 import System.Console.CmdArgs
 import System.Directory
 import System.Environment
 import System.FilePath
-import Data.List.Extra
-import Data.Version
-import General.Util
-import Paths_hoogle(version)
 
 data Language = Haskell | Frege deriving (Data,Typeable,Show,Eq,Enum,Bounded)
 
@@ -23,6 +23,7 @@ data CmdLine
     = Search
         {color :: Maybe Bool
         ,json :: Bool
+        ,jsonl :: Bool
         ,link :: Bool
         ,numbers :: Bool
         ,info :: Bool
@@ -111,6 +112,7 @@ cmdLineMode = cmdArgsMode $ modes [search_ &= auto,generate,server,replay,test]
 search_ = Search
     {color = def &= name "colour" &= help "Use colored output (requires ANSI terminal)"
     ,json = def &= name "json" &= help "Get result as JSON"
+    ,jsonl = def &= name "jsonl" &= help "Get result as JSONL (JSON Lines)"
     ,link = def &= help "Give URL's for each result"
     ,numbers = def &= help "Give counter for each result"
     ,info = def &= help "Give extended information about the first result"


### PR DESCRIPTION
Reason: in situation where one cannot use the shell post-processing it is
easier to output one entry per one line for which JSONL is suitable.

This PR introduces the support in hoogle
