### PR TITLE
Cleanup on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,8 +107,6 @@ I have given several presentations on type searching all available from [my home
 
 The folders in the repository, and their meaning are:
 
-.github/workflows - CI workflow specification
-
 cbits             - C implementation of the text search used by hoogle
 
 docs              - documention on hoogle

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ If you want to search for special symbols in Firefox keyword search, modify the 
 
 ### The Source Code
 
-`$ git clone https://github.com/ndmitchell/hoogle.git`
+    git clone https://github.com/ndmitchell/hoogle.git
 
 Contributions are most welcome. Hoogle is written in Haskell 98 + Heirarchical Modules, I do not wish to change this. Other than that, I'm pretty flexible about most aspects of Hoogle. The [issue tracker](https://github.com/ndmitchell/hoogle/issues) has many outstanding tasks, but please contact me if you have thoughts on doing something major to Hoogle, so I can give some advice.
 

--- a/README.md
+++ b/README.md
@@ -52,14 +52,14 @@ With the set of packages you are searching, you can also restrict the set of mod
 
 To invoke Hoogle type:
 
-    hoogle "[a] -> [b]"
+    $ hoogle "[a] -> [b]"
 
 Note the quotes, otherwise you will redirect the output to the file [b].
 
 To ensure you have data files for the Hackage modules, you will first need to
 type:
 
-    hoogle generate
+    $ hoogle generate
 
 Which will download and build Hoogle databases.
 
@@ -85,7 +85,7 @@ If you want to search for special symbols in Firefox keyword search, modify the 
 
 ### The Source Code
 
-    git clone https://github.com/ndmitchell/hoogle.git
+    $ git clone https://github.com/ndmitchell/hoogle.git
 
 Contributions are most welcome. Hoogle is written in Haskell 98 + Heirarchical Modules, I do not wish to change this. Other than that, I'm pretty flexible about most aspects of Hoogle. The [issue tracker](https://github.com/ndmitchell/hoogle/issues) has many outstanding tasks, but please contact me if you have thoughts on doing something major to Hoogle, so I can give some advice.
 

--- a/README.md
+++ b/README.md
@@ -4,15 +4,15 @@ Hoogle is a Haskell API search engine, which allows you to search many standard 
 
 * **Online version:** https://hoogle.haskell.org/
 * **Hackage page:** https://hackage.haskell.org/package/hoogle
-* **Source code:** http://github.com/ndmitchell/hoogle
+* **Source code:** https://github.com/ndmitchell/hoogle
 * **Bug tracker:** https://github.com/ndmitchell/hoogle/issues
 
 ## Hoogle Use
 
 Hoogle can be used in several ways:
 
-* **Online**, with the web interface at http://hoogle.haskell.org/
-* **In [IRC](http://haskell.org/haskellwiki/Haskell_IRC_channel)**, using the [Lambdabot](http://haskell.org/haskellwiki/Lambdabot) plugin with `@hoogle` and `@hoogle+`
+* **Online**, with the web interface at https://hoogle.haskell.org/
+* **In [IRC](https://wiki.haskell.org/IRC_channel)**, using the [Lambdabot](https://wiki.haskell.org/Lambdabot) plugin with `@hoogle` and `@hoogle+`
 * **From `emacs`**, by means of [`engine-mode`](https://github.com/hrs/engine-mode)
 * **[Installed locally](https://github.com/ndmitchell/hoogle/blob/master/docs/Install.md)**, with either a command line or in a browser
 * **[As a developer](https://github.com/ndmitchell/hoogle/blob/master/docs/API.md)**, through Haskell or JSON APIs.
@@ -33,7 +33,7 @@ Here are some example searches:
 
 ## Scope
 
-By default, searches look at the [Haskell Platform](http://hackage.haskell.org/platform) and [Haskell keywords](http://haskell.org/haskellwiki/Keywords). However, all [Stackage](http://stackage.org) packages are available to search. As some examples:
+By default, searches look at the [Haskell Platform](https://www.haskell.org/platform/) and [Haskell keywords](https://wiki.haskell.org/Keywords). However, all [Stackage](https://stackage.org) packages are available to search. As some examples:
 
 * `mode +cmdargs` searches only the "cmdargs" package
 * `file -base` searches the Haskell Platform, excluding the "base" package
@@ -69,13 +69,13 @@ There is a terminal/curses based UI available through [`cabal install bhoogle`](
 
 ## Chrome Integration
 
-**As a keyword search:** With a keyword search you can type `h map` directly into the location bar to perform a Hoogle search. Go to the [Hoogle website](http://hoogle.haskell.org/) in Chrome, right-click in the Hoogle search field and select "Add as a search engine...". Give it a keyword such as "h".
+**As a keyword search:** With a keyword search you can type `h map` directly into the location bar to perform a Hoogle search. Go to the [Hoogle website](https://hoogle.haskell.org/) in Chrome, right-click in the Hoogle search field and select "Add as a search engine...". Give it a keyword such as "h".
 
 ## Firefox Integration
 
-**From the search bar:** Go to the [Hoogle website](http://hoogle.haskell.org/) in Firefox and click on the drop-down arrow at the left of the search bar, and select the "Add Hoogle" option. Click the arrow again to select Hoogle as your search engine.
+**From the search bar:** Go to the [Hoogle website](https://hoogle.haskell.org/) in Firefox and click on the drop-down arrow at the left of the search bar, and select the "Add Hoogle" option. Click the arrow again to select Hoogle as your search engine.
 
-**As a keyword search:** With a keyword search you can type `h map` directly into the location bar to perform a Hoogle search. Go to the [Hoogle website](http://hoogle.haskell.org/) in Firefox, right-click in the Hoogle search field and select "Add a Keyword for this Search...". Given it a keyword such as "h".
+**As a keyword search:** With a keyword search you can type `h map` directly into the location bar to perform a Hoogle search. Go to the [Hoogle website](https://hoogle.haskell.org/) in Firefox, right-click in the Hoogle search field and select "Add a Keyword for this Search...". Given it a keyword such as "h".
 
 If you want to search for special symbols in Firefox keyword search, modify the keyword search URL to be: `javascript:window.location.href="http://haskell.org/hoogle?q=" + encodeURIComponent("%s")`
 
@@ -121,15 +121,15 @@ src               - haskell source code
 
 I was unaware of any similar tools before starting development, and no other tool has really influenced this tool (except the first on this list). Some related tools are:
 
-* [Google](http://www.google.com/), the leader in online search
-* [Hayoo](http://holumbus.fh-wedel.de/hayoo/hayoo.html), similar to Hoogle, but with less focus on type search
-* [Krugle](http://www.krugle.com/), search code, but no Haskell :(
-* [Cloogle](https://cloogle.org), for the [Clean](http://clean.cs.ru.nl) language
+* [Google](https://www.google.com/), the leader in online search
+* [Hayoo](https://hackage.haskell.org/package/Hayoo), similar to Hoogle, but with less focus on type search
+* [Krugle](https://www.krugle.com/), search code, but no Haskell :(
+* [Cloogle](https://cloogle.org), for the [Clean](https://clean.cs.ru.nl/Clean) language
 
 
 ## Acknowledgements
 
-All code is all &copy; [Neil Mitchell](https://ndmitchell.com/), 2004-present. The initial version was done over my summer holiday, and further work was done during my PhD. During Summer 2008 I was funded to full-time on Hoogle by [Google Summer of Code](https://summerofcode.withgoogle.com/) with the [haskell.org](http://haskell.org/) mentoring organisation. Since then I have been working on Hoogle in my spare time. Various people have given lots of useful ideas, including my PhD supervisor [Colin Runciman](http://www.cs.york.ac.uk/~colin/), and various members of the [Plasma group](https://www.cs.york.ac.uk/plasma/wiki/). In addition, the following people have also contributed code or significant debugging work:
+All code is all &copy; [Neil Mitchell](https://ndmitchell.com/), 2004-present. The initial version was done over my summer holiday, and further work was done during my PhD. During Summer 2008 I was funded to full-time on Hoogle by [Google Summer of Code](https://summerofcode.withgoogle.com/) with the [haskell.org](https://www.haskell.org/) mentoring organisation. Since then I have been working on Hoogle in my spare time. Various people have given lots of useful ideas, including my PhD supervisor [Colin Runciman](https://www-users.cs.york.ac.uk/~colin/), and various members of the [Plasma group](https://www.cs.york.ac.uk/plasma/wiki/). In addition, the following people have also contributed code or significant debugging work:
 
 * [Thomas "Bob" Davie](http://www.cs.kent.ac.uk/people/rpg/tatd2/)
 * [Don Stewart](http://www.cse.unsw.edu.au/~dons/)

--- a/README.md
+++ b/README.md
@@ -129,15 +129,15 @@ I was unaware of any similar tools before starting development, and no other too
 
 All code is all &copy; [Neil Mitchell](https://ndmitchell.com/), 2004-present. The initial version was done over my summer holiday, and further work was done during my PhD. During Summer 2008 I was funded to full-time on Hoogle by [Google Summer of Code](https://summerofcode.withgoogle.com/) with the [haskell.org](https://www.haskell.org/) mentoring organisation. Since then I have been working on Hoogle in my spare time. Various people have given lots of useful ideas, including my PhD supervisor [Colin Runciman](https://www-users.cs.york.ac.uk/~colin/), and various members of the [Plasma group](https://www.cs.york.ac.uk/plasma/wiki/). In addition, the following people have also contributed code or significant debugging work:
 
-* [Thomas "Bob" Davie](http://www.cs.kent.ac.uk/people/rpg/tatd2/)
-* [Don Stewart](http://www.cse.unsw.edu.au/~dons/)
+* Thomas "Bob" Davie
+* Don Stewart
 * Thomas Jager
-* [Gaal Yahas](http://gaal.livejournal.com/)
-* [Mike Dodds](http://www-users.cs.york.ac.uk/~miked/)
-* [Niklas Broberg](http://www.cs.chalmers.se/~d00nibro/)
+* [Gaal Yahas](https://gaal.livejournal.com/)
+* Mike Dodds
+* Niklas Broberg
 * Esa Ilari Vuokko
 * Udo Stenzel
-* [Henk-Jan van Tuyl](http://members.chello.nl/hjgtuyl/)
+* Henk-Jan van Tuyl
 * Gwern Branwen
 * Tillmann Rendel
 * David Waern

--- a/README.md
+++ b/README.md
@@ -97,9 +97,9 @@ Hoogle work is licensed under the [BSD-3-Clause license](https://github.com/ndmi
 
 A lot of related work was done by Rittri [1] and Runciman [2] in the late 80's. Since then Di Cosmo [3] has produced a book on type isomorphisms. Unfortunately the implementations that accompanied the earlier works were for functional languages that have since become less popular.
 
-1. [Mikael Rittri, Using Types as Search Keys in Function Libraries](http://portal.acm.org/citation.cfm?id=99384). Proceedings of the fourth international conference on Functional Programming languages and Computer Architecture: 174-183, June 1989.
-2. [Colin Runciman and Ian Toyn, Retrieving reusable software components by polymorphic type](http://portal.acm.org/citation.cfm?id=99383). Journal of Functional Programming 1 (2): 191-211, April 1991.
-3. [Roberto Di Cosmo, Isomorphisms of types: from lambda-calculus to information retrieval and language design](http://www.pps.jussieu.fr/~dicosmo/Publications/ISObook.html). Birkhauser, 1995. ISBN-0-8176-3763-X
+1. [Mikael Rittri, Using Types as Search Keys in Function Libraries](https://doi.org/10.1145/99370.99384). Proceedings of the fourth international conference on Functional Programming languages and Computer Architecture: 174-183, June 1989.
+2. [Colin Runciman and Ian Toyn, Retrieving reusable software components by polymorphic type](https://doi.org/10.1145/99370.99383). Journal of Functional Programming 1 (2): 191-211, April 1991.
+3. [Roberto Di Cosmo, Isomorphisms of types: from lambda-calculus to information retrieval and language design](https://doi.org/10.1145/270563.571468). Birkhauser, 1995. ISBN-0-8176-3763-X
 
 I have given several presentations on type searching all available from [my home page](https://ndmitchell.com/).
 

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ I was unaware of any similar tools before starting development, and no other too
 
 ## Acknowledgements
 
-All code is all &copy; [Neil Mitchell](http://community.haskell.org/~ndm/), 2004-present. The initial version was done over my summer holiday, and further work was done during my PhD. During Summer 2008 I was funded to full-time on Hoogle by [Google Summer of Code](http://code.google.com/soc/) with the [haskell.org](http://haskell.org/) mentoring organisation. Since then I have been working on Hoogle in my spare time. Various people have given lots of useful ideas, including my PhD supervisor [Colin Runciman](http://www.cs.york.ac.uk/~colin/), and various members of the [Plasma group](http://www.cs.york.ac.uk/plasma/). In addition, the following people have also contributed code or significant debugging work:
+All code is all &copy; [Neil Mitchell](http://community.haskell.org/~ndm/), 2004-present. The initial version was done over my summer holiday, and further work was done during my PhD. During Summer 2008 I was funded to full-time on Hoogle by [Google Summer of Code](http://code.google.com/soc/) with the [haskell.org](http://haskell.org/) mentoring organisation. Since then I have been working on Hoogle in my spare time. Various people have given lots of useful ideas, including my PhD supervisor [Colin Runciman](http://www.cs.york.ac.uk/~colin/), and various members of the [Plasma group](https://www.cs.york.ac.uk/plasma/wiki/). In addition, the following people have also contributed code or significant debugging work:
 
 * [Thomas "Bob" Davie](http://www.cs.kent.ac.uk/people/rpg/tatd2/)
 * [Don Stewart](http://www.cse.unsw.edu.au/~dons/)

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ Hoogle can be used in several ways:
 * **Online**, with the web interface at https://hoogle.haskell.org/
 * **In [IRC](https://wiki.haskell.org/IRC_channel)**, using the [Lambdabot](https://wiki.haskell.org/Lambdabot) plugin with `@hoogle` and `@hoogle+`
 * **From `emacs`**, by means of [`engine-mode`](https://github.com/hrs/engine-mode)
-* **[Installed locally](https://github.com/ndmitchell/hoogle/blob/master/docs/Install.md)**, with either a command line or in a browser
-* **[As a developer](https://github.com/ndmitchell/hoogle/blob/master/docs/API.md)**, through Haskell or JSON APIs.
+* **[Installed locally](./docs/Install.md)**, with either a command line or in a browser
+* **[As a developer](./docs/API.md)**, through Haskell or JSON APIs.
 
 # Searches
 

--- a/README.md
+++ b/README.md
@@ -77,8 +77,6 @@ There is a terminal/curses based UI available through [`cabal install bhoogle`](
 
 **As a keyword search:** With a keyword search you can type `h map` directly into the location bar to perform a Hoogle search. Go to the [Hoogle website](https://hoogle.haskell.org/) in Firefox, right-click in the Hoogle search field and select "Add a Keyword for this Search...". Given it a keyword such as "h".
 
-If you want to search for special symbols in Firefox keyword search, modify the keyword search URL to be: `javascript:window.location.href="http://haskell.org/hoogle?q=" + encodeURIComponent("%s")`
-
 ## Others
 
 * [Doc Browser](https://github.com/qwfy/doc-browser)

--- a/README.md
+++ b/README.md
@@ -1,25 +1,8 @@
 # Hoogle [![Hackage version](https://img.shields.io/hackage/v/hoogle.svg?label=Hackage)](https://hackage.haskell.org/package/hoogle) [![Stackage version](https://www.stackage.org/package/hoogle/badge/nightly?label=Stackage)](https://www.stackage.org/package/hoogle) [![Build status](https://img.shields.io/github/workflow/status/ndmitchell/hoogle/ci.svg)](https://github.com/ndmitchell/hoogle/actions)
 
-## Hoogle 4 vs Hoogle 5
+Hoogle is a Haskell API search engine, which allows you to search many standard Haskell libraries by either function name, or by approximate type signature. The online version can be found at https://hoogle.haskell.org/ and searches [Stackage](https://www.stackage.org/).
 
-Hoogle is in the middle of a transition from version 4 to version 5.
-
-Hoogle 4 is at https://www.haskell.org/hoogle/. It searches the [Haskell platform](https://www.haskell.org/platform/contents.html) as-of 2013. It has good type search.
-
-Hoogle 5 is at https://hoogle.haskell.org/ and on Hackage, so will be obtained by `cabal install hoogle`. It searches [Stackage](https://www.stackage.org/) and is updated daily. It has weaker type search, with various tickets to improve that.
-
-## Other stuff (somewhat outdated)
-
-
-----------
-
-**This page describes how Hoogle 5 might work, and has not yet been fully implemented.**
-
-----------
-
-Hoogle is a Haskell API search engine, which allows you to search many standard Haskell libraries by either function name, or by approximate type signature. To experiment, visit the online version at http://haskell.org/hoogle.
-
-* **Online version:** https://www.haskell.org/hoogle/
+* **Online version:** https://hoogle.haskell.org/
 * **Hackage page:** https://hackage.haskell.org/package/hoogle
 * **Source code:** http://github.com/ndmitchell/hoogle
 * **Bug tracker:** https://github.com/ndmitchell/hoogle/issues
@@ -28,7 +11,7 @@ Hoogle is a Haskell API search engine, which allows you to search many standard 
 
 Hoogle can be used in several ways:
 
-* **Online**, with the web interface at http://haskell.org/hoogle
+* **Online**, with the web interface at http://hoogle.haskell.org/
 * **In [IRC](http://haskell.org/haskellwiki/Haskell_IRC_channel)**, using the [Lambdabot](http://haskell.org/haskellwiki/Lambdabot) plugin with `@hoogle` and `@hoogle+`
 * **From `emacs`**, by means of [`engine-mode`](https://github.com/hrs/engine-mode)
 * **[Installed locally](https://github.com/ndmitchell/hoogle/blob/master/docs/Install.md)**, with either a command line or in a browser
@@ -50,7 +33,7 @@ Here are some example searches:
 
 ## Scope
 
-By default, searches look at the [Haskell Platform](http://hackage.haskell.org/platform) and [Haskell keywords](http://haskell.org/haskellwiki/Keywords). However, all [Hackage](http://hackage.haskell.org) packages are available to search. As some examples:
+By default, searches look at the [Haskell Platform](http://hackage.haskell.org/platform) and [Haskell keywords](http://haskell.org/haskellwiki/Keywords). However, all [Stackage](http://stackage.org) packages are available to search. As some examples:
 
 * `mode +cmdargs` searches only the "cmdargs" package
 * `file -base` searches the Haskell Platform, excluding the "base" package
@@ -86,14 +69,13 @@ There is a terminal/curses based UI available through [`cabal install bhoogle`](
 
 ## Chrome Integration
 
-**As a keyword search:** With a keyword search you can type `h map` directly into the location bar to perform a Hoogle search. Go to the [Hoogle website](http://haskell.org/hoogle/) in Chrome, right-click in the Hoogle search field and select "Add as a search engine...". Give it a keyword such as "h".
-
+**As a keyword search:** With a keyword search you can type `h map` directly into the location bar to perform a Hoogle search. Go to the [Hoogle website](http://hoogle.haskell.org/) in Chrome, right-click in the Hoogle search field and select "Add as a search engine...". Give it a keyword such as "h".
 
 ## Firefox Integration
 
-**From the search bar:** Go to the [Hoogle website](http://haskell.org/hoogle/) in Firefox and click on the drop-down arrow at the left of the search bar, and select the "Add Hoogle" option. Click the arrow again to select Hoogle as your search engine.
+**From the search bar:** Go to the [Hoogle website](http://hoogle.haskell.org/) in Firefox and click on the drop-down arrow at the left of the search bar, and select the "Add Hoogle" option. Click the arrow again to select Hoogle as your search engine.
 
-**As a keyword search:** With a keyword search you can type `h map` directly into the location bar to perform a Hoogle search. Go to the [Hoogle website](http://haskell.org/hoogle/) in Firefox, right-click in the Hoogle search field and select "Add a Keyword for this Search...". Given it a keyword such as "h".
+**As a keyword search:** With a keyword search you can type `h map` directly into the location bar to perform a Hoogle search. Go to the [Hoogle website](http://hoogle.haskell.org/) in Firefox, right-click in the Hoogle search field and select "Add a Keyword for this Search...". Given it a keyword such as "h".
 
 If you want to search for special symbols in Firefox keyword search, modify the keyword search URL to be: `javascript:window.location.href="http://haskell.org/hoogle?q=" + encodeURIComponent("%s")`
 
@@ -103,11 +85,9 @@ If you want to search for special symbols in Firefox keyword search, modify the 
 
 ### The Source Code
 
-<tt>$ darcs get http://code.haskell.org/hoogle/</tt>
+`$ git clone https://github.com/ndmitchell/hoogle.git`
 
-Contributions are most welcome. Hoogle is written in Haskell 98 + Heirarchical Modules, I do not wish to change this. Other than that, I'm pretty flexible about most aspects of Hoogle. The [http://code.google.com/p/ndmitchell/issues/list bug tracker] has many outstanding tasks, but please contact me if you have thoughts on doing something major to Hoogle, so I can give some advice.
-
-
+Contributions are most welcome. Hoogle is written in Haskell 98 + Heirarchical Modules, I do not wish to change this. Other than that, I'm pretty flexible about most aspects of Hoogle. The [issue tracker](https://github.com/ndmitchell/hoogle/issues) has many outstanding tasks, but please contact me if you have thoughts on doing something major to Hoogle, so I can give some advice.
 
 # Background
 
@@ -149,7 +129,7 @@ I was unaware of any similar tools before starting development, and no other too
 
 ## Acknowledgements
 
-All code is all &copy; [Neil Mitchell](http://community.haskell.org/~ndm/), 2004-present. The initial version was done over my summer holiday, and further work was done during my PhD. During Summer 2008 I was funded to full-time on Hoogle by [Google Summer of Code](http://code.google.com/soc/) with the [haskell.org](http://haskell.org/) mentoring organisation. Since then I have been working on Hoogle in my spare time. Various people have given lots of useful ideas, including my PhD supervisor [Colin Runciman](http://www.cs.york.ac.uk/~colin/), and various members of the [Plasma group](https://www.cs.york.ac.uk/plasma/wiki/). In addition, the following people have also contributed code or significant debugging work:
+All code is all &copy; [Neil Mitchell](https://ndmitchell.com/), 2004-present. The initial version was done over my summer holiday, and further work was done during my PhD. During Summer 2008 I was funded to full-time on Hoogle by [Google Summer of Code](http://code.google.com/soc/) with the [haskell.org](http://haskell.org/) mentoring organisation. Since then I have been working on Hoogle in my spare time. Various people have given lots of useful ideas, including my PhD supervisor [Colin Runciman](http://www.cs.york.ac.uk/~colin/), and various members of the [Plasma group](https://www.cs.york.ac.uk/plasma/wiki/). In addition, the following people have also contributed code or significant debugging work:
 
 * [Thomas "Bob" Davie](http://www.cs.kent.ac.uk/people/rpg/tatd2/)
 * [Don Stewart](http://www.cse.unsw.edu.au/~dons/)

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ All code is all &copy; [Neil Mitchell](https://ndmitchell.com/), 2004-present. T
 * Niklas Broberg
 * Esa Ilari Vuokko
 * Udo Stenzel
-* Henk-Jan van Tuyl
+* [Henk-Jan van Tuyl](https://github.com/HJvT)
 * Gwern Branwen
 * Tillmann Rendel
 * David Waern

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ I was unaware of any similar tools before starting development, and no other too
 
 ## Acknowledgements
 
-All code is all &copy; [Neil Mitchell](https://ndmitchell.com/), 2004-present. The initial version was done over my summer holiday, and further work was done during my PhD. During Summer 2008 I was funded to full-time on Hoogle by [Google Summer of Code](http://code.google.com/soc/) with the [haskell.org](http://haskell.org/) mentoring organisation. Since then I have been working on Hoogle in my spare time. Various people have given lots of useful ideas, including my PhD supervisor [Colin Runciman](http://www.cs.york.ac.uk/~colin/), and various members of the [Plasma group](https://www.cs.york.ac.uk/plasma/wiki/). In addition, the following people have also contributed code or significant debugging work:
+All code is all &copy; [Neil Mitchell](https://ndmitchell.com/), 2004-present. The initial version was done over my summer holiday, and further work was done during my PhD. During Summer 2008 I was funded to full-time on Hoogle by [Google Summer of Code](https://summerofcode.withgoogle.com/) with the [haskell.org](http://haskell.org/) mentoring organisation. Since then I have been working on Hoogle in my spare time. Various people have given lots of useful ideas, including my PhD supervisor [Colin Runciman](http://www.cs.york.ac.uk/~colin/), and various members of the [Plasma group](https://www.cs.york.ac.uk/plasma/wiki/). In addition, the following people have also contributed code or significant debugging work:
 
 * [Thomas "Bob" Davie](http://www.cs.kent.ac.uk/people/rpg/tatd2/)
 * [Don Stewart](http://www.cse.unsw.edu.au/~dons/)

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ There is a terminal/curses based UI available through [`cabal install bhoogle`](
 
 ## Firefox Integration
 
-**From the search bar:** Go to the [Hoogle website](https://hoogle.haskell.org/) in Firefox and click on the drop-down arrow at the left of the search bar, and select the "Add Hoogle" option. Click the arrow again to select Hoogle as your search engine.
+**From the search bar:** Go to the [Hoogle website](https://hoogle.haskell.org/) in Firefox and click on the `⋯` symbol at the right of the URL bar, and select the "Add Search Engine" option. Click the hoogle logo at the bottom of the completion dropdown when searching to perform a Hoogle search.
 
 **As a keyword search:** With a keyword search you can type `h map` directly into the location bar to perform a Hoogle search. Go to the [Hoogle website](https://hoogle.haskell.org/) in Firefox, right-click in the Hoogle search field and select "Add a Keyword for this Search...". Given it a keyword such as "h".
 

--- a/README.md
+++ b/README.md
@@ -103,19 +103,21 @@ A lot of related work was done by Rittri [1] and Runciman [2] in the late 80's. 
 
 I have given several presentations on type searching all available from [my home page](http://community.haskell.org/~ndm/hoogle).
 
-## Folders
+## Project Structure
 
-The folders in the distribution, and their meaning are:
+The folders in the repository, and their meaning are:
 
-data - tools to generate a hoogle data file
+.github/workflows - CI workflow specification
 
-docs - documentation on hoogle
+cbits             - C implementation of the text search used by hoogle
 
-misc - presentations, icons, emacs scripts, logos
+docs              - documention on hoogle
 
-src  - source code
+html              - resources for hoogle's web front-end (html, css, javascript, images, etc.)
 
-web  - additional resources for the web front end (css, jpg etc.)
+misc              - scripts, logos, sample data, etc.
+
+src               - haskell source code
 
 ## Similar Tools
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ A lot of related work was done by Rittri [1] and Runciman [2] in the late 80's. 
 2. [Colin Runciman and Ian Toyn, Retrieving reusable software components by polymorphic type](http://portal.acm.org/citation.cfm?id=99383). Journal of Functional Programming 1 (2): 191-211, April 1991.
 3. [Roberto Di Cosmo, Isomorphisms of types: from lambda-calculus to information retrieval and language design](http://www.pps.jussieu.fr/~dicosmo/Publications/ISObook.html). Birkhauser, 1995. ISBN-0-8176-3763-X
 
-I have given several presentations on type searching all available from [my home page](http://community.haskell.org/~ndm/hoogle).
+I have given several presentations on type searching all available from [my home page](https://ndmitchell.com/).
 
 ## Project Structure
 


### PR DESCRIPTION
You mentioned in #369 that the README could use some love, so I've done my best to clean it up a bit.

[Preview of the new README.md](https://github.com/lambdadog/hoogle/blob/ashlynn/readme-tlc/README.md)

This consists of, largely:
 - Replacing dead links and updating ones which redirect or are now at a new location
   + Pointing to your new homepage (https://ndmitchell.com) over the nonexistent `community.haskell.org` one.
   + Using more modern `doi.org` links over `portal.acm.org` ones
   + etc.
 - Using HTTPS over HTTP where possible
 - Removing the Hoogle 4->5 section that's no longer relevant
 - Correcting sections that are now incorrect
   + Updating instructions in Firefox section
   + Update "The Source Code" section to refer to GitHub and the GitHub issue tracker
   + etc.
 - Redo "Folders" section and name it "Project Structure"

Plus just general cleanup and consistency (ex. being consistent with formatting of code blocks).

------

Of note are the dead links I removed in the Acknowledgements section.

I found the best fresh links I could for every dead link I removed, but I wasn't which links would be preferred when I found multiple, so just let me know which links would be preferred and I'll add them to the PR:

 - Thomas "Bob" Davie
   + https://github.com/beelsebob
   + https://noordering.wordpress.com/
 - Don Stewart
   + https://github.com/donsbot
   + https://donsbot.wordpress.com/
 - Gaal Yahas
   + https://github.com/gaal
     - I left the existing link in as it's still functional, but while Gaal was last active on livejournal in April of 2011, they were active on GitHub in May of 2019 so it may be worth a switch
 - Mike Dodds
   + https://github.com/septract
   + https://twitter.com/miike
 - Niklas Broberg
   + https://github.com/niklasbroberg
   + https://research.chalmers.se/en/person/d00nibro