### PR TITLE
Move results before left anchors in tab focus order

### DIFF
--- a/html/hoogle.css
+++ b/html/hoogle.css
@@ -18,6 +18,7 @@ body {
 
 #body {
     flex-grow: 1;
+    position: relative;
 }
 
 a img {
@@ -127,6 +128,9 @@ form {
     padding: 0px;
     margin-left: 10px;
     overflow: hidden;
+    position: absolute;
+    top: 0;
+    left: 0;
 }
 
 #left li {

--- a/src/Action/Server.hs
+++ b/src/Action/Server.hs
@@ -189,9 +189,6 @@ dedupeTake n key = f [] Map.empty
 showResults :: Bool -> Bool -> Maybe FilePath -> [(String, String)] -> [Query] -> [[Target]] -> Markup
 showResults local links haddock args query results = do
     H.h1 $ renderQuery query
-    H.ul ! H.id "left" $ do
-        H.li $ H.b "Packages"
-        mconcat [H.li $ f cat val | (cat,val) <- itemCategories $ concat results, QueryScope True cat val `notElem` query]
     when (null results) $ H.p "No results found"
     forM_ results $ \is@(Target{..}:_) -> do
         H.div ! H.class_ "result" $ do
@@ -203,6 +200,10 @@ showResults local links haddock args query results = do
                         H.div ! H.class_ "links" $ H.a ! H.href (H.stringValue link) $ "Uses"
             H.div ! H.class_ "from" $ showFroms local haddock is
             H.div ! H.class_ "doc newline shut" $ H.preEscapedString targetDocs
+    H.ul ! H.id "left" $ do
+        H.li $ H.b "Packages"
+        mconcat [H.li $ f cat val | (cat,val) <- itemCategories $ concat results, QueryScope True cat val `notElem` query]
+
     where
         useLink :: [Target] -> Maybe String
         useLink [t] | isNothing $ targetPackage t =


### PR DESCRIPTION
When going through the result page navigating with tab, if you wanna go from search input to results, you need to tab through the left anchors.

Rapid access to results seems more important, especially as a user navigating with keyboard could be more inclined to directly typing those left search criteria rather than selecting them with tab.

I did not open an issue about it, so i'm making the proposition as a pull request directly.

I am available if you have any feedback.