### PR TITLE
Fix stackage lts and nightly urls in Generate.hs

### DIFF
--- a/src/Action/Generate.hs
+++ b/src/Action/Generate.hs
@@ -94,8 +94,8 @@ type Download = String -> URL -> IO FilePath
 
 readHaskellOnline :: Timing -> Settings -> Download -> IO (Map.Map PkgName Package, Set.Set PkgName, ConduitT () (PkgName, URL, LBStr) IO ())
 readHaskellOnline timing settings download = do
-    stackageLts <- download "haskell-stackage-lts.txt" "https://www.stackage.org/nightly/cabal.config"
-    stackageNightly <- download "haskell-stackage-nightly.txt" "https://www.stackage.org/lts/cabal.config"
+    stackageLts <- download "haskell-stackage-lts.txt" "https://www.stackage.org/lts/cabal.config"
+    stackageNightly <- download "haskell-stackage-nightly.txt" "https://www.stackage.org/nightly/cabal.config"
     platform <- download "haskell-platform.txt" "https://raw.githubusercontent.com/haskell/haskell-platform/master/hptool/src/Releases2015.hs"
     cabals   <- download "haskell-cabal.tar.gz" "https://hackage.haskell.org/packages/index.tar.gz"
     hoogles  <- download "haskell-hoogle.tar.gz" "https://hackage.haskell.org/packages/hoogle.tar.gz"


### PR DESCRIPTION
I think that url bindings  of `stackageLts` and `stackageNightly` variables are inverted.