### PR TITLE
Action/Server refactors

### DIFF
--- a/src/Action/Server.hs
+++ b/src/Action/Server.hs
@@ -88,8 +88,15 @@ replyServer :: Log -> Bool -> Bool -> Maybe FilePath -> StoreRead -> String -> S
 replyServer log local links haddock store cdn home htmlDir scope Input{..} = case inputURL of
     -- without -fno-state-hack things can get folded under this lambda
     [] -> do
-        let grabBy name = [x | (a,x) <- inputArgs, name a, x /= ""]
+        let
+            -- take from inputArgs, if namePred and value not empty
+            grabBy :: (String -> Bool) -> [String]
+            grabBy namePred = [x | (a,x) <- inputArgs, namePred a, x /= ""]
+            -- take from input Args if value not empty
+            grab :: String -> [String]
             grab name = grabBy (== name)
+            -- take an int from input Args, iff exists, else use default value
+            grabInt :: String -> Int -> Int
             grabInt name def = fromMaybe def $ readMaybe =<< listToMaybe (grab name) :: Int
 
         let qScope = let xs = grab "scope" in [scope | null xs && scope /= ""] ++ xs

--- a/src/Action/Server.hs
+++ b/src/Action/Server.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE ViewPatterns, TupleSections, RecordWildCards, ScopedTypeVariables, PatternGuards #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE MultiWayIf #-}
-{-# OPTIONS_GHC -Wall -Wno-incomplete-patterns -Wno-name-shadowing #-}
 {-# LANGUAGE NamedFieldPuns #-}
 
 module Action.Server(actionServer, actionReplay, action_server_test_, action_server_test) where

--- a/src/Action/Server.hs
+++ b/src/Action/Server.hs
@@ -223,7 +223,7 @@ showResults urlOpts links args query results = do
             H.div ! H.class_ "doc newline shut" $ H.preEscapedString targetDocs
     H.ul ! H.id "left" $ do
         H.li $ H.b "Packages"
-        mconcat [H.li $ f cat val | (cat,val) <- itemCategories $ concat results, QueryScope True cat val `notElem` query]
+        mconcat [H.li $ leftSidebarSearchLinks cat val | (cat,val) <- itemCategories $ concat results, QueryScope True cat val `notElem` query]
 
     where
         useLink :: [Target] -> Maybe String
@@ -231,14 +231,19 @@ showResults urlOpts links args query results = do
             Just $ "https://packdeps.haskellers.com/reverse/" ++ extractName (targetItem t)
         useLink _ = Nothing
 
-        add x = ("?" ++) $ intercalate "&" $ map (joinPair "=") $
+        -- The search URL with an extra filter added to the hoogle query
+        searchURLWithExtraSearchFilter :: String -> String
+        searchURLWithExtraSearchFilter searchFilter = ("?" ++) $ intercalate "&" $ map (joinPair "=") $
             case break ((==) "hoogle" . fst) args of
-                (a,[]) -> a ++ [("hoogle", escapeURL x)]
-                (a,(_,x1):b) -> a ++ [("hoogle", escapeURL $ x1 ++ " " ++ x)] ++ b
+                (a,[]) -> a ++ [("hoogle", escapeURL searchFilter)]
+                (a,(_,x1):b) -> a ++ [("hoogle", escapeURL $ x1 ++ " " ++ searchFilter)] ++ b
 
-        f cat val = do
-            H.a ! H.class_" minus" ! H.href (H.stringValue $ add $ "-" ++ cat ++ ":" ++ val) $ ""
-            H.a ! H.class_ "plus"  ! H.href (H.stringValue $ add $        cat ++ ":" ++ val) $
+        -- Construct two links in the left sidebar,
+        -- one which repeats the current search *with* the respective package or category,
+        -- one *without* the package or category.
+        leftSidebarSearchLinks cat val = do
+            H.a ! H.class_" minus" ! H.href (H.stringValue $ searchURLWithExtraSearchFilter $ "-" ++ cat ++ ":" ++ val) $ ""
+            H.a ! H.class_ "plus"  ! H.href (H.stringValue $ searchURLWithExtraSearchFilter $        cat ++ ":" ++ val) $
                 H.string $ (if cat == "package" then "" else cat ++ ":") ++ val
 
 


### PR DESCRIPTION
A bunch of refactors that fell out of a study session of the module list generation code.

The original goal (at Munihac) was to change the sort order, so that the home module of a target is listed first, but we didn’t get that far.

So this is a bunch of refactors that do not (or should not) change any behavior. Any changes will be submitted in separate PRs.