### PR TITLE
Fixed #403

### DIFF
--- a/src/Action/CmdLine.hs
+++ b/src/Action/CmdLine.hs
@@ -80,8 +80,12 @@ data CmdLine
 
 defaultDatabaseLang :: Language -> IO FilePath
 defaultDatabaseLang lang = do
-    dir <- getAppUserDataDirectory "hoogle"
-    pure $ dir </> "default-" ++ lower (show lang) ++ "-" ++ showVersion (trimVersion 3 version) ++ ".hoo"
+    xdgLocation <- getXdgDirectory XdgData "hoogle"
+    legacyLocation <- getAppUserDataDirectory "hoogle"
+    canIgnoreLegacyPath <- doesPathExist xdgLocation
+    pure $
+        (if canIgnoreLegacyPath then xdgLocation else legacyLocation) </>
+            "default-" ++ lower (show lang) ++ "-" ++ showVersion (trimVersion 3 version) ++ ".hoo"
 
 getCmdLine :: [String] -> IO CmdLine
 getCmdLine args = do


### PR DESCRIPTION
Hoogle will now use the `$XDG_DATA_DIR` instead of `~/.hoogle` as default path but steal keep use the old one as a fall back.

Thanks for the pull request!

By raising this pull request you confirm you are licensing your contribution under all licenses that apply to this project (see LICENSE) and that you have no patents covering your contribution.