### PR TITLE
Added missing field to TLSSettings

### DIFF
--- a/hoogle.cabal
+++ b/hoogle.cabal
@@ -83,7 +83,8 @@ library
         wai-logger,
         warp,
         warp-tls,
-        zlib
+        zlib,
+        data-default-class
 
     c-sources:        cbits/text_search.c
     include-dirs:     cbits

--- a/src/Input/Download.hs
+++ b/src/Input/Download.hs
@@ -13,6 +13,7 @@ import General.Util
 import General.Timing
 import Control.Monad.Trans.Resource
 import Control.Exception.Extra
+import Data.Default.Class
 
 data DownloadInput =
     AlwaysDownloadInput
@@ -45,7 +46,8 @@ downloadFile insecure file url = do
       (TLSSettingsSimple {
         settingDisableCertificateValidation = insecure,
         settingDisableSession = False,
-        settingUseServerName = False
+        settingUseServerName = False,
+        settingClientSupported = def
       }) Nothing
     runResourceT $ do
         response <- C.http request manager


### PR DESCRIPTION
Fixes #423

The crypton-connection library added a new field to TLSSettingsSimple in version 0.4.0.

See: https://github.com/kazu-yamamoto/crypton-connection/pull/3

When the constructor was called it caused the program to crash. This PR should fix that issue.
