### PR TITLE
Fix #288: allow mixing --local with and without paths when generating

### DIFF
--- a/src/Action/Generate.hs
+++ b/src/Action/Generate.hs
@@ -240,11 +240,20 @@ actionGenerate g@Generate{..} = withTiming (if debug then Just $ replaceExtensio
                     warnFlagIgnored "--haddock" "set" (local_ /= []) "--local"
                     warnFlagIgnored "--haddock" "set" (isJust download) "--download"
                     readHaskellHaddock timing settings dir
-                | [""] <- local_ -> do
-                    warnFlagIgnored "--local" "used as flag (no paths)" (isJust download) "--download"
-                    readHaskellGhcpkg timing settings
                 | [] <- local_ -> do readHaskellOnline timing settings doDownload
-                | otherwise -> readHaskellDirs timing settings local_
+                | otherwise -> do
+                    let (localFlag, dirs) = partition (=="") local_
+                    (ghcPkgCbl, ghcPkgWant, ghcPkgSource) <-
+                        if null localFlag
+                            then pure (Map.empty, Set.empty, pure ())
+                            else do
+                                warnFlagIgnored "--local" "used as flag (no paths)" (isJust download) "--download"
+                                readHaskellGhcpkg timing settings
+                    (dirsCbl, dirsWant, dirsSource) <-
+                        if null dirs
+                            then pure (Map.empty, Set.empty, pure ())
+                            else readHaskellDirs timing settings dirs
+                    pure (Map.union dirsCbl ghcPkgCbl, Set.union dirsWant ghcPkgWant, ghcPkgSource >> dirsSource)
         Frege | [] <- local_ -> readFregeOnline timing doDownload
               | otherwise -> errorIO "No support for local Frege databases"
     (cblErrs, popularity) <- evaluate $ packagePopularity cbl


### PR DESCRIPTION
This PR fixes https://github.com/ndmitchell/hoogle/issues/288, allowing to mix the --local parameter with and without paths when generating a database, e.g. `hoogle generate --local --local=foo`. This way you can include both your dependencies and your own code in a single database. Previously, `--local` was ignored if another `--local=foo` was present.

This is not as flexible as the design proposed in https://github.com/ndmitchell/hoogle/blob/master/src/Action/Generate.hs#L40, but it solves the issue for now.