### PR TITLE
Fix haddock links when using --haddock

### DIFF
--- a/src/Action/Server.hs
+++ b/src/Action/Server.hs
@@ -247,7 +247,7 @@ showFroms local haddock xs = mconcat $ intersperse ", " $ flip map pkgs $ \p ->
         pkgs = nubOrd $ map targetPackage xs
 
 showURL :: Bool -> Maybe FilePath -> URL -> String
-showURL _ (Just _) x = "haddock/" ++ dropPrefix "file:///" x
+showURL _ (Just haddock) x = "haddock/" ++ dropPrefix ("file://" ++ haddock) x
 showURL True _ (stripPrefix "file:///" -> Just x) = "file/" ++ x
 showURL _ _ x = x
 


### PR DESCRIPTION
When using --haddock, haddocks are served directly under /haddock, so we have to strip the path when generating links.