### PR TITLE
Action/Generate: Add relocatable option

### DIFF
--- a/docs/Install.md
+++ b/docs/Install.md
@@ -25,9 +25,14 @@ Run `hoogle generate base filepath` to generate an index for only the `base` and
 
 Run `hoogle generate --local` to query `ghc-pkg` and generate links for all packages which have documentation and Hoogle input files generated. By editing your Cabal config file you can have Cabal automatically generate such files when packages are installed. Links to the results will point at your local file system.
 
-### Index a directory
+### Index one or more directories
 
-Run `hoogle generate --local=mydir` to generate an index for the packages in `mydir`, which must contain `foo.txt` Hoogle input files. Links to the results will default to Hackage, but if `@url` directives are in the `.txt` files they can override the link destination.
+Run `hoogle generate --local=mydir1 --local=mydir2` to generate an index for the packages in `mydir1` and `mydir2`, which must contain `foo.txt` Hoogle input files. Links to the results will default to Hackage, but if `@url` directives are in the `.txt` files they can override the link destination.
+
+### Index a directory, producing a relocatable database
+
+Run `hoogle generate --relocatable --local=mydir` to generate an index that supports moving the Haddock directory to a different path without breaking the Haddock links.
+This mode only supports one `--local` directory.
 
 ## Searching a Hoogle database
 

--- a/docs/Install.md
+++ b/docs/Install.md
@@ -31,8 +31,8 @@ Run `hoogle generate --local=mydir1 --local=mydir2` to generate an index for the
 
 ### Index a directory, producing a relocatable database
 
-Run `hoogle generate --relocatable --local=mydir` to generate an index that supports moving the Haddock directory to a different path without breaking the Haddock links.
-This mode only supports one `--local` directory.
+Run `hoogle generate --relocatable=mydir` to generate an index that supports moving the Haddock directory to a different path without breaking the Haddock links.
+This mode acts like `--local` but only supports one directory.
 
 ## Searching a Hoogle database
 

--- a/src/Action/CmdLine.hs
+++ b/src/Action/CmdLine.hs
@@ -45,6 +45,7 @@ data CmdLine
         ,haddock :: Maybe FilePath
         ,debug :: Bool
         ,language :: Language
+        ,relocatable :: Bool
         }
     | Server
         {port :: Int
@@ -151,6 +152,7 @@ generate = Generate
     ,count = Nothing &= name "n" &= help "Maximum number of packages to index (defaults to all)"
     ,haddock = def &= help "Use local haddocks"
     ,debug = def &= help "Generate debug information"
+    ,relocatable = False &= help "Generate a relocatable database"
     } &= help "Generate Hoogle databases"
 
 server = Server

--- a/src/Action/CmdLine.hs
+++ b/src/Action/CmdLine.hs
@@ -45,7 +45,7 @@ data CmdLine
         ,haddock :: Maybe FilePath
         ,debug :: Bool
         ,language :: Language
-        ,relocatable :: Bool
+        ,relocatable :: Maybe FilePath
         }
     | Server
         {port :: Int
@@ -152,7 +152,7 @@ generate = Generate
     ,count = Nothing &= name "n" &= help "Maximum number of packages to index (defaults to all)"
     ,haddock = def &= help "Use local haddocks"
     ,debug = def &= help "Generate debug information"
-    ,relocatable = False &= help "Generate a relocatable database"
+    ,relocatable = Nothing &= help "Index local packages and link to local haddock docs, producing a relocatable database"
     } &= help "Generate Hoogle databases"
 
 server = Server

--- a/src/Action/Generate.hs
+++ b/src/Action/Generate.hs
@@ -141,8 +141,8 @@ readHaskellDirs timing settings prefixToRemove dirs = do
             src <- liftIO $ bstrReadFile file
             dir <- liftIO $ canonicalizePath $ takeDirectory file
             let url = case prefixToRemove of
-                  Just prefix -> makeRelative prefix $ replace "\\" "/" dir ++ "/"
-                  Nothing -> "file://" ++ ['/' | not $ "/" `isPrefixOf` dir] ++ replace "\\" "/" dir ++ "/"
+                  Just prefix -> makeRelative prefix $ normalisePathSeparators dir ++ "/"
+                  Nothing -> "file://" ++ ['/' | not $ "/" `isPrefixOf` dir] ++ normalisePathSeparators dir ++ "/"
             when (isJust $ bstrSplitInfix (bstrPack "@package " <> bstrPack (unPackageName name)) src) $
                 yield (name, url, lbstrFromChunks [src])
     pure (Map.union
@@ -180,7 +180,7 @@ readHaskellGhcpkg timing settings = do
                     src <- liftIO $ bstrReadFile file
                     docs <- liftIO $ canonicalizePath docs
                     let url = "file://" ++ ['/' | not $ all isPathSeparator $ take 1 docs] ++
-                              replace "\\" "/" (addTrailingPathSeparator docs)
+                              normalisePathSeparators (addTrailingPathSeparator docs)
                     yield (name, url, lbstrFromChunks [src])
     cbl <- pure $ let ts = map (both strPack) [("set","stackage"),("set","installed")]
                     in Map.map (\p -> p{packageTags = ts ++ packageTags p}) cbl
@@ -217,7 +217,7 @@ readHaskellHaddock timing settings docBaseDir = do
                 whenM (liftIO $ doesFileExist file) $ do
                     src <- liftIO $ bstrReadFile file
                     let url = ['/' | not $ all isPathSeparator $ take 1 docs] ++
-                              replace "\\" "/" (addTrailingPathSeparator docs)
+                              normalisePathSeparators (addTrailingPathSeparator docs)
                     yield (name, url, lbstrFromChunks [src])
     cbl <- pure $ let ts = map (both strPack) [("set","stackage"),("set","installed")]
                     in Map.map (\p -> p{packageTags = ts ++ packageTags p}) cbl

--- a/src/Action/Generate.hs
+++ b/src/Action/Generate.hs
@@ -246,17 +246,17 @@ actionGenerate g@Generate{..} = withTiming (if debug then Just $ replaceExtensio
         Haskell | Just dir <- haddock -> do
                     warnFlagIgnored "--haddock" "set" (local_ /= []) "--local"
                     warnFlagIgnored "--haddock" "set" (isJust download) "--download"
-                    warnFlagIgnored "--haddock" "set" relocatable "--relocatable"
+                    warnFlagIgnored "--haddock" "set" (isJust relocatable) "--relocatable"
                     readHaskellHaddock timing settings dir
                 | [""] <- local_ -> do
                     warnFlagIgnored "--local" "used as flag (no paths)" (isJust download) "--download"
                     readHaskellGhcpkg timing settings
+                | Just _ <- relocatable, _:_ <- local_ ->
+                    exitFail "Error: --relocatable and --local are mutually exclusive"
+                | Just relocatable' <- relocatable -> do
+                    prefix <- canonicalizePath relocatable'
+                    readHaskellDirs timing settings (Just prefix) [relocatable']
                 | [] <- local_ -> do readHaskellOnline timing settings doDownload
-                | relocatable, _:_:_ <- local_ ->
-                    exitFail "Error: --relocatable needs exactly one --local, or the paths will be ambiguous"
-                | relocatable -> do
-                    prefix <- traverse canonicalizePath $ listToMaybe local_
-                    readHaskellDirs timing settings prefix local_
                 | otherwise -> readHaskellDirs timing settings Nothing local_
         Frege | [] <- local_ -> readFregeOnline timing doDownload
               | otherwise -> errorIO "No support for local Frege databases"

--- a/src/General/Util.hs
+++ b/src/General/Util.hs
@@ -113,7 +113,7 @@ getStatsDebug = do
 
 
 
-exitFail :: String -> IO ()
+exitFail :: String -> IO a
 exitFail msg = do
     hPutStrLn stderr msg
     exitFailure

--- a/src/General/Util.hs
+++ b/src/General/Util.hs
@@ -51,6 +51,7 @@ import Data.Version
 import Data.Int
 import System.IO
 import System.Exit
+import System.FilePath (isPathSeparator)
 import System.Mem
 import GHC.Stats
 import General.Str
@@ -373,7 +374,7 @@ inRanges xs = \x -> maybe False (`inRange` x) $ Map.lookupLE x mp
 
 -- | Turn platform-specific path separators into the canonical / used in URLs.
 normalisePathSeparators :: FilePath -> FilePath
-normalisePathSeparators = replace "\\" "/"
+normalisePathSeparators = fmap $ \c -> if isPathSeparator c then '/' else c
 
 
 general_util_test :: IO ()

--- a/src/General/Util.hs
+++ b/src/General/Util.hs
@@ -24,6 +24,7 @@ module General.Util(
     getStatsPeakAllocBytes, getStatsCurrentLiveBytes, getStatsDebug,
     hackagePackageURL, hackageModuleURL, hackageDeclURL, ghcModuleURL,
     minimum', maximum',
+    normalisePathSeparators,
     general_util_test
     ) where
 
@@ -368,6 +369,11 @@ inRanges xs = \x -> maybe False (`inRange` x) $ Map.lookupLE x mp
             | Just x2 <- Map.lookupLE (fst x) mp, overlap x x2 = add (Map.delete (fst x2) mp) (merge x x2)
             | Just x2 <- Map.lookupGE (fst x) mp, overlap x x2 = add (Map.delete (fst x2) mp) (merge x x2)
             | otherwise = uncurry Map.insert x mp
+
+
+-- | Turn platform-specific path separators into the canonical / used in URLs.
+normalisePathSeparators :: FilePath -> FilePath
+normalisePathSeparators = replace "\\" "/"
 
 
 general_util_test :: IO ()


### PR DESCRIPTION
This is useful for example if you generate the haddocks and the index in CI and deploy them to another machine at a different path.

---

Thanks for the pull request!

By raising this pull request you confirm you are licensing your contribution under all licenses that apply to this project (see LICENSE) and that you have no patents covering your contribution.

If you care, my PR preferences are at https://github.com/ndmitchell/neil#contributions, but they're all guidelines, and I'm not too fussy - you don't have to read them.
