### PR TITLE
When collecting .txt files, check that they resemble valid Hoogle inputs

### DIFF
--- a/src/Action/Generate.hs
+++ b/src/Action/Generate.hs
@@ -135,7 +135,8 @@ readHaskellDirs timing settings dirs = do
             src <- liftIO $ bstrReadFile file
             dir <- liftIO $ canonicalizePath $ takeDirectory file
             let url = "file://" ++ ['/' | not $ "/" `isPrefixOf` dir] ++ replace "\\" "/" dir ++ "/"
-            yield (name, url, lbstrFromChunks [src])
+            when (isJust $ bstrSplitInfix (bstrPack "@package " <> bstrPack (strUnpack name)) src) $
+                yield (name, url, lbstrFromChunks [src])
     pure (Map.union
                 (Map.fromList cabals)
                 (Map.fromListWith (<>) $ map generateBarePackage packages)


### PR DESCRIPTION
Another approach to solve #362. See also #375.