### PR TITLE
Add lower bounds for some dependencies to eliminate invalid build plans

### DIFF
--- a/hoogle.cabal
+++ b/hoogle.cabal
@@ -62,7 +62,7 @@ library
         directory,
         extra >= 1.6.6,
         filepath,
-        ghc-lib-parser >= 9.6,
+        ghc-lib-parser >= 9.6.5,
         old-locale,
         hashable,
         haskell-src-exts >= 1.22 && < 1.24,
@@ -81,12 +81,12 @@ library
         time >= 1.5,
         transformers,
         uniplate,
-        utf8-string,
+        utf8-string >= 0.3.1,
         vector,
         wai,
         wai-logger,
         warp,
-        warp-tls,
+        warp-tls >= 3.4.2,
         zlib
 
     c-sources:        cbits/text_search.c


### PR DESCRIPTION
Reflecting on a number of reports with build issues, let's add a few more lower bounds. Tested with `cabal build --prefer-oldest`.