### PR TITLE
Fix sizeOf in instance Storable Fingerprint

### DIFF
--- a/src/Output/Types.hs
+++ b/src/Output/Types.hs
@@ -267,7 +267,7 @@ fpRaresFold :: (b -> b -> b) -> (Name -> b) -> Fingerprint -> b
 fpRaresFold g f Fingerprint{..} = f fpRare1 `g` f fpRare2 `g` f fpRare3
 
 instance Storable Fingerprint where
-    sizeOf _ = 3*sizeOf name0 + 2
+    sizeOf _ = 4 * sizeOf name0
     alignment _ = 4
     peekByteOff ptr i = Fingerprint
         <$> peekByteOff ptr (i+0) <*> peekByteOff ptr (i+1*w) <*> peekByteOff ptr (i+2*w)


### PR DESCRIPTION
The commit 2d38e16c9977ce72c5e0c3ac68cb1dea8fe76fcd changed `sizeOf (_ :: Fingerprint)` from 64 to 14. This is dangerous, because it means that `pokeByteOff` could be reading `Word32` with an offset not divisible by `sizeOf (_ :: Word32)`. Some architectures are forgiving with regards to unaligned reads / writes, some (such as ARM) are not.

Let's bump `sizeOf (_ :: Fingerprint)` from 14 to 16.

As confirmed in https://github.com/ndmitchell/hoogle/issues/359#issuecomment-3582261466, it fixes #359.