### PR TITLE
Fix #429 use --count when --info is passed

### DIFF
--- a/src/Action/CmdLine.hs
+++ b/src/Action/CmdLine.hs
@@ -134,7 +134,7 @@ search_ = Search
     ,jsonl = def &= name "jsonl" &= help "Get result as JSONL (JSON Lines)"
     ,link = def &= help "Give URL's for each result"
     ,numbers = def &= help "Give counter for each result"
-    ,info = def &= help "Give extended information about the first result"
+    ,info = def &= help "Give extended information about the first n results (set n with --count, default is 1)"
     ,database = def &= typFile &= help "Name of database to use (use .hoo extension)"
     ,count = Nothing &= name "n" &= help "Maximum number of results to return (defaults to 10)"
     ,query = def &= args &= typ "QUERY"

--- a/src/Action/Search.hs
+++ b/src/Action/Search.hs
@@ -56,7 +56,10 @@ actionSearch Search{..} = replicateM_ repeat_ $ -- deliberately reopen the datab
             if null res then
                 putStrLn "No results found"
              else if info then do
-                 putStr $ targetInfo color' q $ headErr res
+                 mapM_ (putStr . targetInfo color' q)
+                  $ (case count of
+                    Just c -> take c
+                    Nothing -> singleton . headErr) res
              else do
                 if | json -> LBS.putStrLn $ JSON.encode $ maybe id take count $ map unHTMLtargetItem res
                    | jsonl -> mapM_ (LBS.putStrLn . JSON.encode) $ maybe id take count $ map unHTMLtargetItem res


### PR DESCRIPTION
Simple fix to print multiple results if `--count` is specified, as discussed in #429. One difference is that count is handled separately for --info, without touching main logic.
<img width="584" height="343" alt="image" src="https://github.com/user-attachments/assets/6fbd3e1d-d790-499f-ae26-020c87ab9bca" />
