### PR TITLE
Bump version to 5.0.19.0

### DIFF
--- a/hoogle.cabal
+++ b/hoogle.cabal
@@ -1,7 +1,7 @@
 cabal-version:      1.18
 build-type:         Simple
 name:               hoogle
-version:            5.0.18.4
+version:            5.0.19.0
 license:            BSD3
 license-file:       LICENSE
 category:           Development


### PR DESCRIPTION
#458 has changed the binary serialisation of Hoogle database, so we must bump the version.