### PR TITLE
Write database to a temporary file, then rename, so that hitting Ctrl+C does not leave you with a corrupted database.

### DIFF
--- a/hoogle.cabal
+++ b/hoogle.cabal
@@ -80,6 +80,7 @@ library
         storable-tuple,
         tar,
         template-haskell,
+        temporary,
         text >= 2,
         time >= 1.5,
         transformers,


### PR DESCRIPTION
Fixes #173.