### PR TITLE
Updated getScope() to specially treat set:all just like set:stackage

### DIFF
--- a/html/hoogle.js
+++ b/html/hoogle.js
@@ -74,7 +74,7 @@ $(function(){
         if (!instant) return;
         function getScope(){
             var v = $scope ? $scope.val() : "";
-            return v == null || v == "set:stackage" ? "" : v;
+            return v == null || v == "set:stackage" || v == "set:all" ? "" : v;
         }
 
         var nowHoogle = $hoogle.val();

--- a/src/Action/Server.hs
+++ b/src/Action/Server.hs
@@ -94,7 +94,7 @@ replyServer log local links haddock store cdn home htmlDir scope Input{..} = cas
 
         let qScope = let xs = grab "scope" in [scope | null xs && scope /= ""] ++ xs
         let qSearch = grabBy (`elem` ["hoogle","q"])
-        let qSource = qSearch ++ filter (/= "set:stackage") qScope
+        let qSource = qSearch ++ filter (`notElem` ["set:stackage","set:all"]) qScope
         let q = concatMap parseQuery qSource
         let (q2, results) = search store q
         let body = showResults local links haddock (filter ((/= "mode") . fst) inputArgs) q2 $
@@ -200,12 +200,15 @@ showResults local links haddock args query results = do
                         H.div ! H.class_ "links" $ H.a ! H.href (H.stringValue link) $ "Uses"
             H.div ! H.class_ "from" $ showFroms local haddock is
             H.div ! H.class_ "doc newline shut" $ H.preEscapedString targetDocs
-    H.ul ! H.id "left" $ -- if there's already a scope query we don't show subquery links because bots will get lost in a maze of links.
-        if (any isQueryScope query) then pure () else do
+    H.ul ! H.id "left" $ -- if there's already a restrictive scope query we don't show subquery links because bots will get lost in a maze of links.
+        if (any isRestrictiveScope query) then pure () else do
             H.li $ H.b "Packages"
             mconcat [H.li $ f cat val | (cat,val) <- itemCategories $ concat results, QueryScope True cat val `notElem` query]
 
     where
+        isRestrictiveScope (QueryScope _ cat _) = cat /= "is"
+        isRestrictiveScope _ = False
+
         useLink :: [Target] -> Maybe String
         useLink [t] | isNothing $ targetPackage t =
             Just $ "https://packdeps.haskellers.com/reverse/" ++ extractName (targetItem t)


### PR DESCRIPTION
On local hoogle, where 'set:all' is the default scope, 'set:all' is not specially excluded from automatic adding to the URL, unlike 'set:stackage' on the public Hoogle server.

This fix changes that so that 'set:all' is treated the same as 'set:stackage' to be specially treated as being ''.