### PR TITLE
Fix typos

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -140,7 +140,7 @@ Changelog for Hoogle (* = API change, @ = database format change)
     G521, make sure it works with inverted color preferences
     Rewrite from scratch
 4.2.38, released 2015-01-28
-    #96, allow certicate verification failures
+    #96, allow certificate verification failures
     #95, allow a higher version of Cabal on older GHCs
 4.2.37, released 2015-01-13
     #94, GHC 7.10 support

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ There is a terminal/curses based UI available through [`cabal install bhoogle`](
 
     $ git clone https://github.com/ndmitchell/hoogle.git
 
-Contributions are most welcome. Hoogle is written in Haskell 98 + Heirarchical Modules, I do not wish to change this. Other than that, I'm pretty flexible about most aspects of Hoogle. The [issue tracker](https://github.com/ndmitchell/hoogle/issues) has many outstanding tasks, but please contact me if you have thoughts on doing something major to Hoogle, so I can give some advice.
+Contributions are most welcome. Hoogle is written in Haskell 98 + Hierarchical Modules, I do not wish to change this. Other than that, I'm pretty flexible about most aspects of Hoogle. The [issue tracker](https://github.com/ndmitchell/hoogle/issues) has many outstanding tasks, but please contact me if you have thoughts on doing something major to Hoogle, so I can give some advice.
 
 # Background
 
@@ -107,7 +107,7 @@ The folders in the repository, and their meaning are:
 
 cbits             - C implementation of the text search used by hoogle
 
-docs              - documention on hoogle
+docs              - documentation on hoogle
 
 html              - resources for hoogle's web front-end (html, css, javascript, images, etc.)
 

--- a/docs/TypeSearch.md
+++ b/docs/TypeSearch.md
@@ -96,7 +96,7 @@ A generic instaniable proof system, where:
 
 How close are two proofs?
 
-Do they talk about the same things? Are the things easily convertable?
+Do they talk about the same things? Are the things easily convertible?
 
 apply some rules, which rules got used. can i do bulk apply? things that are only one rule apart? can i start small and evolve upwards?
 

--- a/src/Action/CmdLine.hs
+++ b/src/Action/CmdLine.hs
@@ -96,7 +96,7 @@ defaultDatabaseLang lang = do
           ++ "since xdg location is available (" ++ xdgLocation ++")."
         pure xdgLocation
       (False, True) -> do
-        -- TODO: renable after release
+        -- TODO: re-enable after release
         --hPutStrLn stderr $ "Warning: " ++ legacyLocation ++ " is deprecated."
         --  ++ "Consider moving it to $XDG_DATA_HOME/hoogle (" ++ xdgLocation ++ ")"
         pure legacyLocation
@@ -157,7 +157,7 @@ server = Server
     {port = 8080 &= typ "INT" &= help "Port number"
     ,cdn = "" &= typ "URL" &= help "URL prefix to use"
     ,logs = "" &= opt "log.txt" &= typFile &= help "File to log requests to (defaults to stdout)"
-    ,local = False &= help "Allow following file:// links, restricts to 127.0.0.1  Set --host explicitely (including to '*' for any host) to override the localhost-only behaviour"
+    ,local = False &= help "Allow following file:// links, restricts to 127.0.0.1  Set --host explicitly (including to '*' for any host) to override the localhost-only behaviour"
     ,haddock = def &= help "Serve local haddocks from a specified directory"
     ,scope = def &= help "Default scope to start with"
     ,links = def &= help "Display extra links"

--- a/src/Input/Cabal.hs
+++ b/src/Input/Cabal.hs
@@ -48,7 +48,7 @@ import qualified Distribution.SPDX as SPDX
 data Package = Package
     {packageTags :: ![(Str, Str)] -- ^ The Tag information, e.g. (category,Development) (author,Neil Mitchell).
     ,packageLibrary :: !Bool -- ^ True if the package provides a library (False if it is only an executable with no API)
-    ,packageSynopsis :: !Str -- ^ The synposis, grabbed from the top section.
+    ,packageSynopsis :: !Str -- ^ The synopsis, grabbed from the top section.
     ,packageVersion :: !Str -- ^ The version, grabbed from the top section.
     ,packageDepends :: ![PkgName] -- ^ The list of packages that this package directly depends on.
     ,packageDocs :: !(Maybe FilePath) -- ^ Directory where the documentation is located
@@ -76,7 +76,7 @@ packagePopularity :: Map.Map PkgName Package -> ([String], Map.Map PkgName Int)
 packagePopularity cbl = mp `seq` (errs, mp)
     where
         mp = Map.map length good
-        errs =  [ unPackageName user ++ ".cabal: Import of non-existant package " ++ unPackageName name ++
+        errs =  [ unPackageName user ++ ".cabal: Import of non-existent package " ++ unPackageName name ++
                           (if null rest then "" else ", also imported by " ++ show (length rest) ++ " others")
                 | (name, user:rest) <- Map.toList bad]
         (good, bad)  = Map.partitionWithKey (\k _ -> k `Map.member` cbl) $

--- a/src/Input/Item.hs
+++ b/src/Input/Item.hs
@@ -207,7 +207,7 @@ highlightItem plain safe dull bold qs x
         highlight x = mconcatMap (\xs@((b,_):_) -> let s = map snd xs in if b then bold s else dull s) $
                     groupOn fst $ zip (findQueries x) x
             where
-                -- generates a bool mask, which is only true for charachters that compose given queries
+                -- generates a bool mask, which is only true for characters that compose given queries
                 -- e.g. [ "query" "ya" ] -> [ "AqUeRyAA" ] -> 01111110
                 findQueries :: String -> [Bool]
                 findQueries (x:xs) | m > 0 = replicate m True ++ drop (m - 1) (findQueries xs)


### PR DESCRIPTION
Found via `codespell -S html -L caf,ans,nam,udo,withs,te,headerr,shouldbe,modul,cafs`

