### PR TITLE
Fix TLS handshake failure during download

### DIFF
--- a/hoogle.cabal
+++ b/hoogle.cabal
@@ -83,6 +83,7 @@ library
         temporary,
         text >= 2,
         time >= 1.5,
+        tls,
         transformers,
         uniplate,
         utf8-string >= 0.3.1,

--- a/src/Input/Download.hs
+++ b/src/Input/Download.hs
@@ -9,6 +9,8 @@ import Data.Conduit.Binary (sinkFile)
 import Data.Default.Class
 import qualified Network.HTTP.Conduit as C
 import Network.Connection
+import Network.TLS
+import Network.TLS.Extra.Cipher (ciphersuite_strong)
 import qualified Data.Conduit as C
 import General.Util
 import General.Timing
@@ -42,13 +44,15 @@ downloadInput timing insecure download dir name url = do
 downloadFile :: Bool -> FilePath -> String -> IO ()
 downloadFile insecure file url = do
     let request = C.parseRequest_ url
+
     manager <- C.newManager $ C.mkManagerSettings
       (TLSSettingsSimple {
         settingDisableCertificateValidation = insecure,
         settingDisableSession = False,
         settingUseServerName = False,
-        settingClientSupported = def
+        settingClientSupported = def{supportedCiphers = ciphersuite_strong}
       }) Nothing
+
     runResourceT $ do
         response <- C.http request manager
         C.runConduit $ C.responseBody response C..| sinkFile file


### PR DESCRIPTION
Use 'ciphersuite_strong' in the TLS manager to resolve handshake failures (DecodeError) due to rejection of weak cipher from remote server when building database through `hoogle generate`.

Before:

```bash
$ hoogle generate                                                               
                                                                                                            
Starting generate                                                                                           
Downloading https://www.stackage.org/lts/cabal.config... hoogle: Uncaught exception http-client-0.7.19-e53e031a3080635351a782ae473941335ff5cb434b654af0da963246f7167366:Network.HTTP.Client.Types.HttpException:
                                                                                                            
HttpExceptionRequest Request {                        
  host                 = "www.stackage.org"
  port                 = 443
  secure               = True
  requestHeaders       = []
  path                 = "/lts/cabal.config"
  queryString          = ""
  method               = "GET"
  proxy                = Nothing
  rawBody              = False
  redirectCount        = 10
  responseTimeout      = ResponseTimeoutDefault
  requestVersion       = HTTP/1.1
  proxySecureMode      = ProxySecureWithConnect
}
 (InternalException (HandshakeFailed (Error_Protocol "expecting server hello, got alert : [(AlertLevel_Fatal,DecodeError)]" HandshakeFailure)))                                                                          

While handling HttpExceptionRequest Request {
  |   host                 = "www.stackage.org"
  |   port                 = 443
  |   secure               = True
  |   requestHeaders       = []
  |   path                 = "/lts/cabal.config"
  |   queryString          = ""
  |   method               = "GET"
  |   proxy                = Nothing
  |   rawBody              = False
  |   redirectCount        = 10
  |   responseTimeout      = ResponseTimeoutDefault
  |   requestVersion       = HTTP/1.1
  |   proxySecureMode      = ProxySecureWithConnect
  | }
  |  (InternalException (HandshakeFailed (Error_Protocol "expecting server hello, got alert : [(AlertLevel_Fatal,DecodeError)]" HandshakeFailure)))                                                                      

HasCallStack backtrace:
  throwIO, called at ./Control/Monad/Trans/Resource.hs:195:13 in resourcet-1.3.0-7299c6173b690f5eb16d3064231923041dd3dc557a27f9dbaf609a7a01dc2448:Control.Monad.Trans.Resource         
```

After:

```
$ hoogle -- generate
Starting generate
Downloading https://www.stackage.org/lts/cabal.config... 1.41s
Downloading https://www.stackage.org/nightly/cabal.config... 1.43s
Downloading https://raw.githubusercontent.com/haskell/haskell-platform/master/hptool/src/Releases2015.hs... 1.10s
Downloading https://hackage.haskell.org/packages/index.tar.gz... 5m08s
Downloading https://hackage.haskell.org/packages/hoogle.tar.gz... 
...
```